### PR TITLE
Improve UCSI/DP alt mode reliability, Himax multitouch, and image build robustness

### DIFF
--- a/.github/workflows/img_pack.yml
+++ b/.github/workflows/img_pack.yml
@@ -22,7 +22,7 @@ jobs:
       uses: softprops/action-gh-release@v2
       with:
         files: |
-          ${{ github.workspace }}/*img.xz
+          ${{ github.workspace }}/*img.zst
           ${{ github.workspace }}/*pkg.tar.zst
         tag_name: packages
       env:

--- a/README.MD
+++ b/README.MD
@@ -29,6 +29,13 @@ Use mainline with [recommended patches](./patch%20sets/recommended). (My AUR [he
 
 Kernel parameter: `clk_ignore_unused pd_ignore_unused arm64.nopauth efi=noruntime`
 
+Current working GRUB defaults on my MateBook E Go:
+
+```sh
+GRUB_CMDLINE_LINUX_DEFAULT="fbcon=rotate:1 loglevel=3"
+GRUB_CMDLINE_LINUX="clk_ignore_unused pd_ignore_unused arm64.nopauth efi=noruntime"
+```
+
 ## Prebuilt Bianry
 See [release](https://github.com/right-0903/linux-ego/releases/tag/packages).
 

--- a/gaokun-ec-dkms/Makefile
+++ b/gaokun-ec-dkms/Makefile
@@ -4,7 +4,7 @@ MODVER = 1.0
 
 obj-m += $(MODNAME).o
 
-obj-m += gaokun-battery.o \
+obj-m += huawei-gaokun-battery.o \
 	 ucsi_huawei_gaokun.o
 
 

--- a/gaokun-ec-dkms/ucsi.h
+++ b/gaokun-ec-dkms/ucsi.h
@@ -61,6 +61,7 @@ struct dentry;
  * struct ucsi_operations - UCSI I/O operations
  * @read_version: Read implemented UCSI version
  * @read_cci: Read CCI register
+ * @poll_cci: Read CCI register while polling with notifications disabled
  * @read_message_in: Read message data from UCSI
  * @sync_control: Blocking control operation
  * @async_control: Non-blocking control operation
@@ -75,10 +76,13 @@ struct dentry;
 struct ucsi_operations {
 	int (*read_version)(struct ucsi *ucsi, u16 *version);
 	int (*read_cci)(struct ucsi *ucsi, u32 *cci);
+	int (*poll_cci)(struct ucsi *ucsi, u32 *cci);
 	int (*read_message_in)(struct ucsi *ucsi, void *val, size_t val_len);
-	int (*sync_control)(struct ucsi *ucsi, u64 command);
+	int (*sync_control)(struct ucsi *ucsi, u64 command, u32 *cci,
+			    void *data, size_t size);
 	int (*async_control)(struct ucsi *ucsi, u64 command);
-	bool (*update_altmodes)(struct ucsi *ucsi, struct ucsi_altmode *orig,
+	bool (*update_altmodes)(struct ucsi *ucsi, u8 recipient,
+				struct ucsi_altmode *orig,
 				struct ucsi_altmode *updated);
 	void (*update_connector)(struct ucsi_connector *con);
 	void (*connector_status)(struct ucsi_connector *con);
@@ -464,7 +468,8 @@ void ucsi_altmode_update_active(struct ucsi_connector *con);
 int ucsi_resume(struct ucsi *ucsi);
 
 void ucsi_notify_common(struct ucsi *ucsi, u32 cci);
-int ucsi_sync_control_common(struct ucsi *ucsi, u64 command);
+int ucsi_sync_control_common(struct ucsi *ucsi, u64 command, u32 *cci,
+			     void *data, size_t size);
 
 #if IS_ENABLED(CONFIG_POWER_SUPPLY)
 int ucsi_register_port_psy(struct ucsi_connector *con);

--- a/gaokun-ec-dkms/ucsi_huawei_gaokun.c
+++ b/gaokun-ec-dkms/ucsi_huawei_gaokun.c
@@ -18,6 +18,7 @@
 #include <linux/usb/pd_vdo.h>
 #include <linux/usb/typec_altmode.h>
 #include <linux/usb/typec_dp.h>
+#include <linux/usb/typec_mux.h>
 #include <linux/workqueue_types.h>
 
 #include "ucsi.h"
@@ -25,14 +26,18 @@
 #define EC_EVENT_UCSI	0x21
 #define EC_EVENT_USB	0x22
 
+#define GAOKUN_UCSI_REGISTER_DELAY	(3 * HZ)
+#define GAOKUN_UCSI_RETRY_DELAY		(10 * HZ)
+#define GAOKUN_UCSI_MAX_RETRIES		3
+#define GAOKUN_HPD_REPLAY_DELAY		(1 * HZ)
+#define GAOKUN_HPD_REPLAY_COUNT		3
+
 #define GAOKUN_CCX_MASK		GENMASK(1, 0)
 #define GAOKUN_MUX_MASK		GENMASK(3, 2)
 
 #define GAOKUN_DPAM_MASK	GENMASK(3, 0)
 #define GAOKUN_HPD_STATE_MASK	BIT(4)
 #define GAOKUN_HPD_IRQ_MASK	BIT(5)
-
-#define GET_IDX(updt) (ffs(updt) - 1)
 
 #define CCX_TO_ORI(ccx) (++ccx % 3) /* convert ccx to enum typec_orientation */
 
@@ -77,10 +82,14 @@ struct gaokun_ucsi_reg {
 
 struct gaokun_ucsi_port {
 	struct completion usb_ack;
+	struct delayed_work no_usb_work;
+	struct delayed_work hpd_work;
 	spinlock_t lock; /* serializing port resource access */
 
 	struct gaokun_ucsi *ucsi;
 	struct auxiliary_device *bridge;
+	struct typec_mux *typec_mux;
+	struct typec_switch *typec_sw;
 
 	int idx;
 	enum gaokun_ucsi_ccx ccx;
@@ -89,6 +98,7 @@ struct gaokun_ucsi_port {
 	u16 svid;
 	u8 hpd_state;
 	u8 hpd_irq;
+	u8 hpd_replays_left;
 };
 
 struct gaokun_ucsi {
@@ -100,6 +110,10 @@ struct gaokun_ucsi {
 	struct notifier_block nb;
 	u16 version;
 	u8 num_ports;
+	u8 register_retries;
+	bool ports_initialized;
+	bool notifier_registered;
+	bool ucsi_registered;
 };
 
 /* -------------------------------------------------------------------------- */
@@ -196,6 +210,7 @@ static void gaokun_ucsi_connector_status(struct ucsi_connector *con)
 const struct ucsi_operations gaokun_ucsi_ops = {
 	.read_version = gaokun_ucsi_read_version,
 	.read_cci = gaokun_ucsi_read_cci,
+	.poll_cci = gaokun_ucsi_read_cci,
 	.read_message_in = gaokun_ucsi_read_message_in,
 	.sync_control = ucsi_sync_control_common,
 	.async_control = gaokun_ucsi_async_control,
@@ -267,33 +282,94 @@ static void gaokun_ucsi_port_update(struct gaokun_ucsi_port *port,
 	spin_unlock_irqrestore(&port->lock, flags);
 }
 
-static int gaokun_ucsi_refresh(struct gaokun_ucsi *uec)
+static unsigned int gaokun_ucsi_refresh(struct gaokun_ucsi *uec)
 {
 	struct gaokun_ucsi_reg ureg;
-	int ret, idx;
+	unsigned int updates = 0;
+	int ret;
+	u8 port_updates;
+	int idx;
 
 	ret = gaokun_ec_ucsi_get_reg(uec->ec, &ureg);
 	if (ret)
-		return GAOKUN_UCSI_NO_PORT_UPDATE;
+		return 0;
 
 	uec->num_ports = ureg.num_ports;
-	idx = GET_IDX(ureg.port_updt);
+	port_updates = ureg.port_updt;
+	for (idx = 0; idx < ureg.num_ports; idx++) {
+		if (!(port_updates & BIT(idx)))
+			continue;
+		gaokun_ucsi_port_update(&uec->ports[idx], ureg.port_data);
+		updates |= BIT(idx);
+	}
 
-	if (idx < 0 || idx >= ureg.num_ports)
-		return GAOKUN_UCSI_NO_PORT_UPDATE;
+	return updates;
+}
 
-	gaokun_ucsi_port_update(&uec->ports[idx], ureg.port_data);
-	return idx;
+static unsigned long gaokun_ucsi_typec_mux_mode(const struct gaokun_ucsi_port *port)
+{
+	switch (port->svid) {
+	case USB_SID_DISPLAYPORT:
+		switch (port->mode) {
+		case DP_PIN_ASSIGN_C:
+			return TYPEC_DP_STATE_C;
+		case DP_PIN_ASSIGN_D:
+			return TYPEC_DP_STATE_D;
+		case DP_PIN_ASSIGN_E:
+			return TYPEC_DP_STATE_E;
+		default:
+			return TYPEC_STATE_SAFE;
+		}
+	case USB_SID_PD:
+		return TYPEC_STATE_USB;
+	default:
+		return TYPEC_STATE_SAFE;
+	}
 }
 
 static void gaokun_ucsi_handle_altmode(struct gaokun_ucsi_port *port)
 {
 	struct gaokun_ucsi *uec = port->ucsi;
+	struct typec_mux_state state = {};
+	struct typec_altmode dp_alt = {};
+	struct typec_displayport_data dp_data = {};
 	int idx = port->idx;
+	int ret;
 
 	if (idx >= uec->ucsi->cap.num_connectors) {
 		dev_warn(uec->dev, "altmode port out of range: %d\n", idx);
 		return;
+	}
+
+	if (port->typec_sw) {
+		ret = typec_switch_set(port->typec_sw, CCX_TO_ORI(port->ccx));
+		if (ret)
+			dev_warn(uec->dev, "failed to set orientation switch for port %d: %d\n",
+				 idx, ret);
+	}
+
+	if (port->typec_mux) {
+		state.mode = gaokun_ucsi_typec_mux_mode(port);
+
+		if (port->svid == USB_SID_DISPLAYPORT) {
+			dp_alt.svid = USB_TYPEC_DP_SID;
+			dp_alt.mode = USB_TYPEC_DP_MODE;
+			state.alt = &dp_alt;
+
+			dp_data.status = DP_STATUS_ENABLED;
+			if (port->hpd_state)
+				dp_data.status |= DP_STATUS_HPD_STATE;
+			if (port->hpd_irq)
+				dp_data.status |= DP_STATUS_IRQ_HPD;
+			dp_data.conf = DP_CONF_UFP_U_AS_UFP_D |
+				       DP_CONF_SET_PIN_ASSIGN(port->mode);
+			state.data = &dp_data;
+		}
+
+		ret = typec_mux_set(port->typec_mux, &state);
+		if (ret)
+			dev_warn(uec->dev, "failed to set typec mux for port %d: mode=0x%lx ret=%d\n",
+				 idx, state.mode, ret);
 	}
 
 	/* UCSI callback .connector_status() have set orientation */
@@ -303,56 +379,103 @@ static void gaokun_ucsi_handle_altmode(struct gaokun_ucsi_port *port)
 					  connector_status_connected :
 					  connector_status_disconnected);
 
+	if (port->hpd_state && port->svid == USB_SID_DISPLAYPORT) {
+		port->hpd_replays_left = GAOKUN_HPD_REPLAY_COUNT;
+		mod_delayed_work(system_wq, &port->hpd_work, GAOKUN_HPD_REPLAY_DELAY);
+	} else {
+		port->hpd_replays_left = 0;
+		cancel_delayed_work(&port->hpd_work);
+	}
+
 	gaokun_ec_ucsi_pan_ack(uec->ec, port->idx);
 }
 
-static void gaokun_ucsi_altmode_notify_ind(struct gaokun_ucsi *uec)
-{
-	int idx;
-
-	if (!uec->ucsi->connector) { /* slow to register */
-		dev_err_ratelimited(uec->dev, "ucsi connector is not initialized yet\n");
-		return;
-	}
-
-	idx = gaokun_ucsi_refresh(uec);
-	if (idx == GAOKUN_UCSI_NO_PORT_UPDATE)
-		gaokun_ec_ucsi_pan_ack(uec->ec, idx); /* ack directly if no update */
-	else
-		gaokun_ucsi_handle_altmode(&uec->ports[idx]);
-}
-
-/*
- * When inserting, 2 UCSI events(connector change) are followed by USB events.
- * If we received one USB event, that means USB events are not blocked, so we
- * can complelte for all ports, and we should signal all events.
- */
-static void gaokun_ucsi_complete_usb_ack(struct gaokun_ucsi *uec)
+static void gaokun_ucsi_hpd_replay_worker(struct work_struct *work)
 {
 	struct gaokun_ucsi_port *port;
-	int idx = 0;
 
-	while (idx < uec->num_ports) {
-		port = &uec->ports[idx++];
+	port = container_of(work, struct gaokun_ucsi_port, hpd_work.work);
+
+	if (!port->bridge || !port->hpd_state || port->svid != USB_SID_DISPLAYPORT)
+		return;
+
+	drm_aux_hpd_bridge_notify(&port->bridge->dev, connector_status_connected);
+
+	if (port->hpd_replays_left > 1) {
+		port->hpd_replays_left--;
+		mod_delayed_work(system_wq, &port->hpd_work, GAOKUN_HPD_REPLAY_DELAY);
+	} else {
+		port->hpd_replays_left = 0;
+	}
+}
+
+static unsigned int gaokun_ucsi_altmode_notify_ind(struct gaokun_ucsi *uec)
+{
+	unsigned int updates;
+	int idx;
+
+	if (!uec->ucsi_registered || !uec->ucsi->connector) {
+		dev_warn_ratelimited(uec->dev,
+				     "ucsi connector is not initialized yet, acking pending event\n");
+		gaokun_ec_ucsi_pan_ack(uec->ec, GAOKUN_UCSI_NO_PORT_UPDATE);
+		return 0;
+	}
+
+	updates = gaokun_ucsi_refresh(uec);
+	if (!updates) {
+		gaokun_ec_ucsi_pan_ack(uec->ec, GAOKUN_UCSI_NO_PORT_UPDATE);
+		return 0;
+	}
+
+	for (idx = 0; idx < uec->num_ports; idx++) {
+		if (!(updates & BIT(idx)))
+			continue;
+		gaokun_ucsi_handle_altmode(&uec->ports[idx]);
+	}
+
+	return updates;
+}
+
+static void gaokun_ucsi_no_usb_event_worker(struct work_struct *work)
+{
+	struct gaokun_ucsi_port *port;
+	struct gaokun_ucsi *uec;
+
+	port = container_of(work, struct gaokun_ucsi_port, no_usb_work.work);
+	uec = port->ucsi;
+
+	if (completion_done(&port->usb_ack))
+		return;
+
+	dev_warn(uec->dev, "No USB EVENT, triggered by UCSI EVENT");
+	gaokun_ucsi_altmode_notify_ind(uec);
+}
+
+static void gaokun_ucsi_complete_usb_ack(struct gaokun_ucsi *uec, unsigned int updates)
+{
+	struct gaokun_ucsi_port *port;
+	int idx;
+
+	for (idx = 0; idx < uec->num_ports; idx++) {
+		if (!(updates & BIT(idx)))
+			continue;
+		port = &uec->ports[idx];
 		if (!completion_done(&port->usb_ack))
 			complete_all(&port->usb_ack);
 	}
 }
 
 /*
- * USB event is necessary for enabling altmode, the event should follow
- * UCSI event, if not after timeout(this notify may be disabled somehow),
- * then force to enable altmode.
+ * Apply the EC-reported switch and mux state only after the USB follow-up
+ * event arrives. If that event never comes, force a refresh after a timeout.
  */
-static void gaokun_ucsi_handle_no_usb_event(struct gaokun_ucsi *uec, int idx)
+static void gaokun_ucsi_schedule_no_usb_check(struct gaokun_ucsi *uec, int idx)
 {
 	struct gaokun_ucsi_port *port;
 
 	port = &uec->ports[idx];
-	if (!wait_for_completion_timeout(&port->usb_ack, 2 * HZ)) {
-		dev_warn(uec->dev, "No USB EVENT, triggered by UCSI EVENT");
-		gaokun_ucsi_altmode_notify_ind(uec);
-	}
+	reinit_completion(&port->usb_ack);
+	mod_delayed_work(system_wq, &port->no_usb_work, 2 * HZ);
 }
 
 static int gaokun_ucsi_notify(struct notifier_block *nb,
@@ -360,18 +483,30 @@ static int gaokun_ucsi_notify(struct notifier_block *nb,
 {
 	u32 cci;
 	struct gaokun_ucsi *uec = container_of(nb, struct gaokun_ucsi, nb);
+	unsigned int updates;
 
 	switch (action) {
 	case EC_EVENT_USB:
-		gaokun_ucsi_complete_usb_ack(uec);
-		gaokun_ucsi_altmode_notify_ind(uec);
+		/*
+		 * USB follow-up events are port-specific. Completing all ports
+		 * here lets activity on one connector mask a missing follow-up
+		 * event on the other connector.
+		 */
+		updates = gaokun_ucsi_altmode_notify_ind(uec);
+		gaokun_ucsi_complete_usb_ack(uec, updates);
 		return NOTIFY_OK;
 
 	case EC_EVENT_UCSI:
-		gaokun_ucsi_read_cci(uec->ucsi, &cci);
-		ucsi_notify_common(uec->ucsi, cci);
+		if (gaokun_ucsi_read_cci(uec->ucsi, &cci)) {
+			dev_warn(uec->dev, "failed to read CCI for UCSI event\n");
+			return NOTIFY_OK;
+		}
+
 		if (UCSI_CCI_CONNECTOR(cci))
-			gaokun_ucsi_handle_no_usb_event(uec, UCSI_CCI_CONNECTOR(cci) - 1);
+			gaokun_ucsi_schedule_no_usb_check(uec,
+							  UCSI_CCI_CONNECTOR(cci) - 1);
+
+		ucsi_notify_common(uec->ucsi, cci);
 
 		return NOTIFY_OK;
 
@@ -383,14 +518,24 @@ static int gaokun_ucsi_notify(struct notifier_block *nb,
 static int gaokun_ucsi_ports_init(struct gaokun_ucsi *uec)
 {
 	struct gaokun_ucsi_port *ucsi_port;
-	struct gaokun_ucsi_reg ureg = {};
 	struct device *dev = uec->dev;
 	struct fwnode_handle *fwnode;
 	int i, ret, num_ports;
 	u32 port;
 
-	gaokun_ec_ucsi_get_reg(uec->ec, &ureg);
-	num_ports = ureg.num_ports;
+	if (uec->ports_initialized)
+		return 0;
+
+	num_ports = 0;
+	device_for_each_child_node(dev, fwnode)
+		num_ports++;
+
+	if (num_ports <= 0) {
+		dev_err(dev, "no connector child nodes found for UCSI bridge setup\n");
+		return -ENODEV;
+	}
+
+	uec->num_ports = num_ports;
 	uec->ports = devm_kcalloc(dev, num_ports, sizeof(*(uec->ports)),
 				  GFP_KERNEL);
 	if (!uec->ports)
@@ -402,6 +547,10 @@ static int gaokun_ucsi_ports_init(struct gaokun_ucsi *uec)
 		ucsi_port->idx = i;
 		ucsi_port->ucsi = uec;
 		init_completion(&ucsi_port->usb_ack);
+		INIT_DELAYED_WORK(&ucsi_port->no_usb_work,
+				  gaokun_ucsi_no_usb_event_worker);
+		INIT_DELAYED_WORK(&ucsi_port->hpd_work,
+				  gaokun_ucsi_hpd_replay_worker);
 		spin_lock_init(&ucsi_port->lock);
 	}
 
@@ -421,8 +570,31 @@ static int gaokun_ucsi_ports_init(struct gaokun_ucsi *uec)
 		ucsi_port = &uec->ports[port];
 		ucsi_port->bridge = devm_drm_dp_hpd_bridge_alloc(dev, to_of_node(fwnode));
 		if (IS_ERR(ucsi_port->bridge)) {
+			dev_err_probe(dev, PTR_ERR(ucsi_port->bridge),
+				      "failed to allocate DP HPD bridge for connector %u\n",
+				      port);
 			fwnode_handle_put(fwnode);
 			return PTR_ERR(ucsi_port->bridge);
+		}
+
+		ucsi_port->typec_mux = fwnode_typec_mux_get(fwnode);
+		if (IS_ERR(ucsi_port->typec_mux)) {
+			ret = PTR_ERR(ucsi_port->typec_mux);
+			dev_err_probe(dev, ret,
+				      "failed to get typec mux for connector %u\n",
+				      port);
+			fwnode_handle_put(fwnode);
+			return ret;
+		}
+
+		ucsi_port->typec_sw = fwnode_typec_switch_get(fwnode);
+		if (IS_ERR(ucsi_port->typec_sw)) {
+			ret = PTR_ERR(ucsi_port->typec_sw);
+			dev_err_probe(dev, ret,
+				      "failed to get typec switch for connector %u\n",
+				      port);
+			fwnode_handle_put(fwnode);
+			return ret;
 		}
 	}
 
@@ -431,9 +603,34 @@ static int gaokun_ucsi_ports_init(struct gaokun_ucsi *uec)
 			continue;
 
 		ret = devm_drm_dp_hpd_bridge_add(dev, uec->ports[i].bridge);
-		if (ret)
+		if (ret) {
+			dev_err_probe(dev, ret,
+				      "failed to add DP HPD bridge for connector %d\n", i);
 			return ret;
+		}
 	}
+
+	uec->ports_initialized = true;
+
+	return 0;
+}
+
+static int gaokun_ucsi_ec_init(struct gaokun_ucsi *uec)
+{
+	struct gaokun_ucsi_reg ureg = {};
+	int ret;
+
+	ret = gaokun_ec_ucsi_get_reg(uec->ec, &ureg);
+	if (ret)
+		return ret;
+
+	if (ureg.num_ports <= 0)
+		return -ENODEV;
+
+	if (ureg.num_ports > uec->num_ports)
+		return -EINVAL;
+
+	uec->num_ports = ureg.num_ports;
 
 	return 0;
 }
@@ -447,15 +644,45 @@ static void gaokun_ucsi_register_worker(struct work_struct *work)
 	uec = container_of(work, struct gaokun_ucsi, work.work);
 	ucsi = uec->ucsi;
 
+	ret = gaokun_ucsi_ports_init(uec);
+	if (ret)
+		goto retry;
+
+	ret = gaokun_ucsi_ec_init(uec);
+	if (ret)
+		goto retry;
+
+	ret = ucsi_register(ucsi);
+	if (ret) {
+		dev_err_probe(ucsi->dev, ret, "ucsi register failed\n");
+		goto retry;
+	}
+
+	uec->ucsi_registered = true;
+
 	ret = gaokun_ec_register_notify(uec->ec, &uec->nb);
 	if (ret) {
 		dev_err_probe(ucsi->dev, ret, "notifier register failed\n");
+		ucsi_unregister(ucsi);
+		uec->ucsi_registered = false;
+		goto retry;
+	}
+
+	uec->notifier_registered = true;
+
+	return;
+
+retry:
+	if (++uec->register_retries > GAOKUN_UCSI_MAX_RETRIES) {
+		dev_err(uec->dev, "giving up on UCSI registration after %u attempts\n",
+			uec->register_retries);
 		return;
 	}
 
-	ret = ucsi_register(ucsi);
-	if (ret)
-		dev_err_probe(ucsi->dev, ret, "ucsi register failed\n");
+	dev_warn(uec->dev, "retrying UCSI registration in %u seconds (attempt %u/%u)\n",
+		 jiffies_to_msecs(GAOKUN_UCSI_RETRY_DELAY) / 1000,
+		 uec->register_retries, GAOKUN_UCSI_MAX_RETRIES);
+	schedule_delayed_work(&uec->work, GAOKUN_UCSI_RETRY_DELAY);
 }
 
 static int gaokun_ucsi_probe(struct auxiliary_device *adev,
@@ -479,17 +706,22 @@ static int gaokun_ucsi_probe(struct auxiliary_device *adev,
 
 	ret = gaokun_ucsi_ports_init(uec);
 	if (ret)
-		return ret;
+		return dev_err_probe(dev, ret, "failed to initialize UCSI ports\n");
 
 	uec->ucsi = ucsi_create(dev, &gaokun_ucsi_ops);
 	if (IS_ERR(uec->ucsi))
-		return PTR_ERR(uec->ucsi);
+		return dev_err_probe(dev, PTR_ERR(uec->ucsi),
+				     "failed to create UCSI instance\n");
 
 	ucsi_set_drvdata(uec->ucsi, uec);
 	auxiliary_set_drvdata(adev, uec);
 
-	/* EC can't handle UCSI properly in the early stage */
-	schedule_delayed_work(&uec->work, 3 * HZ);
+	/*
+	 * Do not touch EC UCSI state or register for EC notifications until the
+	 * platform has settled; boot-time EC events can otherwise race with
+	 * UCSI initialization and leave the EC interrupt storming.
+	 */
+	schedule_delayed_work(&uec->work, GAOKUN_UCSI_REGISTER_DELAY);
 
 	return 0;
 }
@@ -497,9 +729,25 @@ static int gaokun_ucsi_probe(struct auxiliary_device *adev,
 static void gaokun_ucsi_remove(struct auxiliary_device *adev)
 {
 	struct gaokun_ucsi *uec = auxiliary_get_drvdata(adev);
+	int i;
 
-	gaokun_ec_unregister_notify(uec->ec, &uec->nb);
-	ucsi_unregister(uec->ucsi);
+	cancel_delayed_work_sync(&uec->work);
+
+	if (uec->ports_initialized) {
+		for (i = 0; i < uec->num_ports; i++) {
+			cancel_delayed_work_sync(&uec->ports[i].no_usb_work);
+			cancel_delayed_work_sync(&uec->ports[i].hpd_work);
+			typec_switch_put(uec->ports[i].typec_sw);
+			typec_mux_put(uec->ports[i].typec_mux);
+		}
+	}
+
+	if (uec->notifier_registered)
+		gaokun_ec_unregister_notify(uec->ec, &uec->nb);
+
+	if (uec->ucsi_registered)
+		ucsi_unregister(uec->ucsi);
+
 	ucsi_destroy(uec->ucsi);
 }
 

--- a/touchscreen-hx83121a-dkms/himax-spi.c
+++ b/touchscreen-hx83121a-dkms/himax-spi.c
@@ -17,9 +17,11 @@
 #include <linux/input/touchscreen.h>
 #include <linux/interrupt.h>
 #include <linux/limits.h>
+#include <linux/mutex.h>
 #include <linux/module.h>
 #include <linux/spi/spi.h>
 #include <linux/math.h>
+#include <linux/workqueue.h>
 
 #define HIMAX_BUS_RETRY					3
 /* SPI bus read header length */
@@ -89,6 +91,13 @@ HIMAX_MAX_TX + HIMAX_MAX_RX) * 2)
 
 /* SPI CS setup time */
 #define HIMAX_SPI_CS_SETUP_TIME				300
+#define HIMAX_BOOT_REINIT_RETRIES			6
+#define HIMAX_BOOT_REINIT_DELAY_MS			500
+#define HIMAX_BOOT_LATE_REINIT_DELAY_MS			3000
+#define HIMAX_OPEN_REINIT_DELAY_MS			1000
+#define HIMAX_RESUME_REINIT_RETRIES			10
+#define HIMAX_RESUME_REINIT_DELAY_MS			300
+#define HIMAX_RESUME_REINIT_INITIAL_DELAY_MS		3000
 /* HIMAX SPI function select, 1st byte of any SPI command sequence */
 #define HIMAX_SPI_FUNCTION_READ				0xf3
 #define HIMAX_SPI_FUNCTION_WRITE			0xf2
@@ -108,14 +117,17 @@ struct himax_ts_data {
 	u32 event_buf_sz;
 	/* lock for irq_save */
 	spinlock_t irq_lock;
+	struct mutex op_lock;
 	bool irq_enabled;
 	struct gpio_desc *gpiod_rst;
 	struct device *dev;
 	struct spi_device *spi;
 	struct input_dev *input_dev;
 	struct touchscreen_properties props;
+	struct delayed_work reinit_work;
 	u8 touch_start_frames;
 	bool touch_active;
+	bool reinit_on_open;
 	struct himax_track {
 		bool active;
 		u8 seen;
@@ -124,6 +136,14 @@ struct himax_ts_data {
 		s32 y;
 	} tracks[HIMAX_MAX_TOUCH];
 };
+
+static void himax_report_tracked_state(struct himax_ts_data *ts, bool report_on);
+static int himax_input_open(struct input_dev *dev);
+static void himax_input_close(struct input_dev *dev);
+static int himax_disable_fw_reload(struct himax_ts_data *ts);
+static int himax_mcu_power_on_init(struct himax_ts_data *ts);
+static int himax_mcu_check_crc(struct himax_ts_data *ts, u32 start_addr,
+			       int reload_length, u32 *crc_result);
 
 /*
  * 1st byte is the spi function select, 2nd byte is the command belong to the
@@ -570,6 +590,8 @@ static int himax_input_dev_config(struct himax_ts_data *ts)
 
 	ts->input_dev = input_dev;
 	input_set_drvdata(input_dev, ts);
+	input_dev->open = himax_input_open;
+	input_dev->close = himax_input_close;
 
 	input_dev->name = "Himax Capacitive TouchScreen";
 	input_dev->phys = "input/ts";
@@ -594,6 +616,146 @@ static int himax_input_dev_config(struct himax_ts_data *ts)
 
 	return 0;
 }
+
+static int himax_input_open(struct input_dev *dev)
+{
+	struct himax_ts_data *ts = input_get_drvdata(dev);
+
+	if (!ts->reinit_on_open)
+		return 0;
+
+	ts->reinit_on_open = false;
+	mod_delayed_work(system_wq, &ts->reinit_work,
+			 msecs_to_jiffies(HIMAX_OPEN_REINIT_DELAY_MS));
+
+	return 0;
+}
+
+static void himax_input_close(struct input_dev *dev)
+{
+	struct himax_ts_data *ts = input_get_drvdata(dev);
+
+	/*
+	 * Greeter/session handoff closes and reopens the input node under a
+	 * new userspace stack. Queue a fresh controller reinit for the next
+	 * opener so logout does not require a manual module reload.
+	 */
+	ts->reinit_on_open = true;
+}
+
+static void himax_release_all_touches(struct himax_ts_data *ts)
+{
+	memset(ts->tracks, 0, sizeof(ts->tracks));
+	ts->touch_start_frames = 0;
+	ts->touch_active = false;
+
+	if (ts->input_dev)
+		himax_report_tracked_state(ts, false);
+}
+
+static int himax_hw_reinit(struct himax_ts_data *ts, bool check_crc)
+{
+	u32 crc_hw;
+	int ret;
+
+	himax_int_enable(ts, false);
+	himax_release_all_touches(ts);
+
+	ret = hx83121a_chip_detect(ts);
+	if (ret) {
+		dev_err(ts->dev, "%s: IC detect failed\n", __func__);
+		goto out_enable_irq;
+	}
+
+	if (check_crc) {
+		ret = himax_mcu_check_crc(ts, 0, HIMAX_HX83121A_FLASH_SIZE, &crc_hw);
+		if (ret || crc_hw) {
+			if (!ret && crc_hw)
+				ret = -EINVAL;
+			dev_err(ts->dev, "hw crc failed, fw broken, fix it on windows\n");
+			goto out_enable_irq;
+		}
+	}
+
+	ret = himax_disable_fw_reload(ts);
+	if (ret < 0) {
+		dev_err(ts->dev, "%s: disable FW reload fail\n", __func__);
+		goto out_enable_irq;
+	}
+
+	ret = himax_mcu_power_on_init(ts);
+	if (ret < 0)
+		dev_err(ts->dev, "%s: power-on init failed\n", __func__);
+
+out_enable_irq:
+	himax_int_enable(ts, true);
+	return ret;
+}
+
+static int himax_hw_reinit_retry(struct himax_ts_data *ts, bool check_crc,
+				 int retries, unsigned int delay_ms,
+				 const char *reason)
+{
+	int ret;
+	int attempt;
+
+	for (attempt = 1; attempt <= retries; attempt++) {
+		ret = himax_hw_reinit(ts, check_crc);
+		if (!ret)
+			return 0;
+
+		if (attempt < retries) {
+			dev_warn(ts->dev,
+				 "%s reinit attempt %d/%d failed, retrying in %u ms\n",
+				 reason, attempt, retries, delay_ms);
+			msleep(delay_ms);
+		}
+	}
+
+	dev_err(ts->dev, "%s reinit failed after %d attempts\n", reason, retries);
+	return ret;
+}
+
+static void himax_reinit_work(struct work_struct *work)
+{
+	struct himax_ts_data *ts = container_of(to_delayed_work(work),
+						struct himax_ts_data, reinit_work);
+
+	mutex_lock(&ts->op_lock);
+	dev_info(ts->dev, "running deferred controller reinit\n");
+	himax_hw_reinit_retry(ts, false,
+			      HIMAX_RESUME_REINIT_RETRIES,
+			      HIMAX_RESUME_REINIT_DELAY_MS,
+			      "late");
+	mutex_unlock(&ts->op_lock);
+}
+
+static ssize_t inplace_reset_store(struct device *dev,
+				   struct device_attribute *attr,
+				   const char *buf, size_t count)
+{
+	struct himax_ts_data *ts = dev_get_drvdata(dev);
+	bool do_reset;
+	int ret;
+
+	ret = kstrtobool(buf, &do_reset);
+	if (ret)
+		return ret;
+
+	if (!do_reset)
+		return count;
+
+	cancel_delayed_work_sync(&ts->reinit_work);
+	mutex_lock(&ts->op_lock);
+	ret = himax_hw_reinit(ts, false);
+	mutex_unlock(&ts->op_lock);
+	if (ret)
+		return ret;
+
+	return count;
+}
+
+static DEVICE_ATTR_WO(inplace_reset);
 
 /* -------------------------------------------------------------------------- */
 /* 中断处理 */
@@ -807,6 +969,11 @@ static inline int himax_dist2(const struct input_mt_pos *a,
 	return dx * dx + dy * dy;
 }
 
+static void himax_reset_track(struct himax_track *trk)
+{
+	memset(trk, 0, sizeof(*trk));
+}
+
 static void himax_track_contacts(struct himax_ts_data *ts,
 				 struct input_mt_pos *det,
 				 int det_cnt)
@@ -844,9 +1011,20 @@ static void himax_track_contacts(struct himax_ts_data *ts,
 				trk->seen++;
 			det_used[best_det] = true;
 		} else {
+			/*
+			 * A candidate touch must be observed on consecutive
+			 * frames before it is allowed to start a new contact.
+			 * This drops short idle noise bursts before they can be
+			 * promoted into a reported touch.
+			 */
+			if (!ts->touch_active) {
+				himax_reset_track(trk);
+				continue;
+			}
+
 			trk->missed++;
 			if (trk->missed > HIMAX_TRACK_LOST_FRAMES)
-				trk->active = false;
+				himax_reset_track(trk);
 		}
 	}
 
@@ -903,6 +1081,12 @@ static void himax_report_tracked_state(struct himax_ts_data *ts, bool report_on)
 				       ts->tracks[i].x, ts->tracks[i].y, true);
 	}
 
+	/*
+	 * Also emit single-touch pointer emulation so compositors that still
+	 * key parts of their touchscreen handling off ABS_X/ABS_Y or BTN_TOUCH
+	 * observe a coherent state across suspend/resume.
+	 */
+	input_mt_report_pointer_emulation(ts->input_dev, true);
 	input_mt_sync_frame(ts->input_dev);
 	input_sync(ts->input_dev);
 }
@@ -915,11 +1099,15 @@ static irqreturn_t himax_ts_thread(int irq, void *data)
 	int cnt;
 	int stable_cnt;
 	bool report_on = true;
+	irqreturn_t irq_ret = IRQ_HANDLED;
+
+	mutex_lock(&ts->op_lock);
 
 	if (hx83121a_gaokun_read_event_stack(ts)) {
 		dev_err(ts->dev, "failed to get touch data!\n");
 		himax_mcu_ic_reset(ts, true);
-		return IRQ_NONE;
+		irq_ret = IRQ_NONE;
+		goto out_unlock;
 	}
 
 	// dump_frame((void *)ptr - OFST, true);
@@ -957,7 +1145,9 @@ static irqreturn_t himax_ts_thread(int irq, void *data)
 	/* 这里报告给系统的坐标数据可以通过 evtest 查看 */
 	himax_report_tracked_state(ts, report_on);
 
-	return IRQ_HANDLED;
+out_unlock:
+	mutex_unlock(&ts->op_lock);
+	return irq_ret;
 }
 
 static int himax_mcu_assign_sorting_mode(struct himax_ts_data *ts, u8 *tmp_data_in)
@@ -1148,7 +1338,6 @@ static int himax_spi_probe(struct spi_device *spi)
 {
 	int ret;
 	struct himax_ts_data *ts;
-	u32 crc_hw;
 
 	ts = devm_kzalloc(&spi->dev, sizeof(struct himax_ts_data), GFP_KERNEL);
 	if (!ts)
@@ -1179,20 +1368,10 @@ static int himax_spi_probe(struct spi_device *spi)
 		return -ENOMEM;
 
 	spin_lock_init(&ts->irq_lock);
+	mutex_init(&ts->op_lock);
+	INIT_DELAYED_WORK(&ts->reinit_work, himax_reinit_work);
 	dev_set_drvdata(&spi->dev, ts);
 	spi_set_drvdata(spi, ts);
-
-	ret = hx83121a_chip_detect(ts);
-	if (ret) {
-		dev_err(ts->dev, "%s: IC detect failed\n", __func__);
-		return ret;
-	}
-
-	ret = himax_mcu_check_crc(ts, 0, HIMAX_HX83121A_FLASH_SIZE, &crc_hw);
-	if (ret || crc_hw) {
-		dev_err(ts->dev, "hw crc failed, fw broken, fix it on windows\n");
-		return ret;
-	}
 
 	ret = himax_input_dev_config(ts);
 	if (ret) {
@@ -1208,12 +1387,59 @@ static int himax_spi_probe(struct spi_device *spi)
 		return ret;
 	}
 	ts->irq_enabled = true;
-	himax_int_enable(ts, false);
-	himax_disable_fw_reload(ts);
-	himax_mcu_power_on_init(ts);
-	himax_int_enable(ts, true);
-	return ret;
+
+	ret = himax_hw_reinit_retry(ts, true,
+				    HIMAX_BOOT_REINIT_RETRIES,
+				    HIMAX_BOOT_REINIT_DELAY_MS,
+				    "boot");
+	if (ret)
+		return ret;
+
+	ret = device_create_file(ts->dev, &dev_attr_inplace_reset);
+	if (ret) {
+		dev_err(ts->dev, "failed to create inplace_reset sysfs attribute\n");
+		return ret;
+	}
+
+	mod_delayed_work(system_wq, &ts->reinit_work,
+			 msecs_to_jiffies(HIMAX_BOOT_LATE_REINIT_DELAY_MS));
+
+	return 0;
 }
+
+static int himax_spi_suspend(struct device *dev)
+{
+	struct himax_ts_data *ts = dev_get_drvdata(dev);
+
+	cancel_delayed_work_sync(&ts->reinit_work);
+	mutex_lock(&ts->op_lock);
+	himax_int_enable(ts, false);
+	himax_release_all_touches(ts);
+	mutex_unlock(&ts->op_lock);
+
+	return 0;
+}
+
+static int himax_spi_resume(struct device *dev)
+{
+	struct himax_ts_data *ts = dev_get_drvdata(dev);
+
+	mod_delayed_work(system_wq, &ts->reinit_work,
+			 msecs_to_jiffies(HIMAX_RESUME_REINIT_INITIAL_DELAY_MS));
+
+	return 0;
+}
+
+static void himax_spi_remove(struct spi_device *spi)
+{
+	struct himax_ts_data *ts = spi_get_drvdata(spi);
+
+	cancel_delayed_work_sync(&ts->reinit_work);
+	device_remove_file(ts->dev, &dev_attr_inplace_reset);
+}
+
+static DEFINE_SIMPLE_DEV_PM_OPS(himax_spi_pm_ops,
+				himax_spi_suspend, himax_spi_resume);
 
 static const struct spi_device_id himax_spi_ids[] = {
 	{ .name = "hx83121a" },
@@ -1231,8 +1457,10 @@ static struct spi_driver himax_spi_driver = {
 	.driver = {
 		.name = "himax-spi",
 		.of_match_table = himax_spi_of_match,
+		.pm = pm_sleep_ptr(&himax_spi_pm_ops),
 	},
 	.probe = himax_spi_probe,
+	.remove = himax_spi_remove,
 	.id_table = himax_spi_ids,
 };
 module_spi_driver(himax_spi_driver);

--- a/touchscreen-hx83121a-dkms/himax-spi.c
+++ b/touchscreen-hx83121a-dkms/himax-spi.c
@@ -16,6 +16,7 @@
 #include <linux/input/mt.h>
 #include <linux/input/touchscreen.h>
 #include <linux/interrupt.h>
+#include <linux/limits.h>
 #include <linux/module.h>
 #include <linux/spi/spi.h>
 #include <linux/math.h>
@@ -29,6 +30,7 @@
 #define HIMAX_REG_SZ					4U
 #define HIMAX_MAX_RX					60U
 #define HIMAX_MAX_TX					40U
+#define HIMAX_MAX_TOUCH				10
 #define HIMAX_HX83121A_SAFE_MODE_PASSWORD		0x9527
 /* FIXME: this is for hx83120j */
 #define HIMAX_HX83121A_STACK_SIZE			128U
@@ -100,8 +102,10 @@ union himax_dword_data {
 
 struct himax_ts_data {
 	u8 *xfer_buf;
+	u8 *event_buf;
 	u32 spi_xfer_max_sz;
 	u32 xfer_buf_sz;
+	u32 event_buf_sz;
 	/* lock for irq_save */
 	spinlock_t irq_lock;
 	bool irq_enabled;
@@ -110,7 +114,15 @@ struct himax_ts_data {
 	struct spi_device *spi;
 	struct input_dev *input_dev;
 	struct touchscreen_properties props;
-	unsigned long update_time;
+	u8 touch_start_frames;
+	bool touch_active;
+	struct himax_track {
+		bool active;
+		u8 seen;
+		u8 missed;
+		s32 x;
+		s32 y;
+	} tracks[HIMAX_MAX_TOUCH];
 };
 
 /*
@@ -150,7 +162,8 @@ static int himax_spi_read(struct himax_ts_data *ts, u8 cmd, u8 *buf, u32 len)
 	if (ret < 0)
 		return ret;
 
-	memcpy(buf, ts->xfer_buf + HIMAX_BUS_R_HLEN, len);
+	/* Destination may alias xfer_buf when caller reuses driver buffers. */
+	memmove(buf, ts->xfer_buf + HIMAX_BUS_R_HLEN, len);
 	return 0;
 }
 
@@ -546,7 +559,6 @@ static int hx83121a_chip_detect(struct himax_ts_data *ts)
 
 /* -------------------------------------------------------------------------- */
 /* input 子系统 */
-#define HIMAX_MAX_TOUCH 10
 static int himax_input_dev_config(struct himax_ts_data *ts)
 {
 	struct input_dev *input_dev;
@@ -583,26 +595,6 @@ static int himax_input_dev_config(struct himax_ts_data *ts)
 	return 0;
 }
 
-static void himax_report_state(struct himax_ts_data *ts,
-			       struct input_mt_pos *pos,
-			       int touch_num)
-{
-	int i, slots[HIMAX_MAX_TOUCH];
-
-	input_mt_assign_slots(ts->input_dev, slots, pos, touch_num, 0);
-	for (i = 0; i < touch_num; i++) {
-		input_mt_slot(ts->input_dev, slots[i]);
-		input_mt_report_slot_state(ts->input_dev, MT_TOOL_FINGER, true);
-
-		touchscreen_report_pos(ts->input_dev, &ts->props,
-				       pos[i].x, pos[i].y, true);
-		// input_report_abs(ts->input_dev, ABS_MT_TOUCH_MAJOR, );
-	}
-
-	input_mt_sync_frame(ts->input_dev);
-	input_sync(ts->input_dev);
-}
-
 /* -------------------------------------------------------------------------- */
 /* 中断处理 */
 
@@ -611,9 +603,9 @@ static int hx83121a_gaokun_read_event_stack(struct himax_ts_data *ts)
 	u32 i;
 	int ret;
 	const u32 max_trunk_sz = ts->spi_xfer_max_sz - HIMAX_BUS_R_HLEN;
-	u8 *buf = ts->xfer_buf;
+	u8 *buf = ts->event_buf;
 
-	memset(ts->xfer_buf, 0x00, ts->xfer_buf_sz);
+	memset(ts->event_buf, 0x00, ts->event_buf_sz);
 	size_t length = HIMAX_HX83121A_FULL_STACK_SZ; /* FIXME: use actual size. */
 
 	for (i = 0; i < length; i += max_trunk_sz) {
@@ -630,6 +622,13 @@ static int hx83121a_gaokun_read_event_stack(struct himax_ts_data *ts)
 
 #define EQUILIBRIUM	0x8000
 #define THRESHOLD	0xa0 /* casual, 拉高有助于防止乱跳, 代价是灵敏度降低 */
+#define HIMAX_PEAK_MIN	0x160
+#define HIMAX_PEAK_QUALITY_MIN	0x300
+#define HIMAX_TOUCH_START_DEBOUNCE	2
+#define HIMAX_NEW_TOUCH_DEBOUNCE	2
+#define HIMAX_TRACK_MATCH_DIST2	(420 * 420)
+#define HIMAX_TRACK_LOST_FRAMES	2
+#define HIMAX_TOUCH_SEPARATION_GRID	5
 static u16 simple_filter(int val)
 {
 	/* 触控区貌似只会大于 EQUILIBRIUM, 如果是稳定的数据, 只会出现 0x8000 和 0x8000+ */
@@ -638,8 +637,12 @@ static u16 simple_filter(int val)
 }
 
 /* TODO: 可以创建一个 sysfs 用于和用户空间 IO, 分析, 处理, 数据 等等 */
-static void dump_frame(u16 *ptr, bool raw)
+static void __maybe_unused dump_frame(u16 *ptr, bool raw)
 {
+	/* Debug helper kept for bring-up and signal quality checks. */
+	if (!IS_ENABLED(CONFIG_DYNAMIC_DEBUG))
+		return;
+
 	char buf[1024];
 
 	pr_warn("Frame start\n");
@@ -664,61 +667,104 @@ static inline u16 dd2d(u16 *arr, int tx, int rx)
 	       ? simple_filter(le16_to_cpup(arr + tx * HIMAX_MAX_RX + rx)) : 0;
 }
 
-#define DIS(pos0, pos1) \
-( abs(pos0->x - pos1->x) + abs(pos0->y - pos1->y) )
-
-#define REPLACE(dst, src) \
-*dst = *src;
-
-static bool is_new_point(u16 *arr, struct input_mt_pos *pos, int cnt)
+static bool is_local_peak(u16 *arr, int tx, int rx)
 {
-	struct input_mt_pos *pos0 = pos + cnt;
-	u16 val = dd2d(arr, pos0->y, pos0->x);
-	struct input_mt_pos *posi;
-	int i;
+	u16 vc = dd2d(arr, tx, rx);
+	u16 vl, vr, vu, vd;
+	u16 quality;
 
-	if (!val)
+	if (vc < HIMAX_PEAK_MIN)
 		return false;
 
-	/* 检查 pos0 周围有没有点, 有的话保留 rawdata 更大那一个 */
-	for (i = cnt - 1; i >= 0; --i) {
-		posi = pos + i;
+	vl = dd2d(arr, tx, rx - 1);
+	vr = dd2d(arr, tx, rx + 1);
+	vu = dd2d(arr, tx - 1, rx);
+	vd = dd2d(arr, tx + 1, rx);
 
-		/* 存在之前记录的点与 '新点' 过于接近, 二选一, 保留 rawdata 更大的那个 */
-		if (DIS(pos0, posi) < 3) {
-			if (val > dd2d(arr, posi->y, posi->x))
-				REPLACE(posi, pos0); // TODO: 处理替换后与其他点距离小于3的情况?
-			return false;
-		}
-	}
+	if (vc < vl || vc < vr || vc < vu || vc < vd)
+		return false;
 
-	/*
-	 * 与所有点都距离大于 2, 是新点, 该点早已被插入, 只要标记 true 返回即可
-	 * cnt == 0 时也会直接 true
-	 */
+	/* Flat areas are usually baseline noise, not a finger peak. */
+	if (vc == vl && vc == vr && vc == vu && vc == vd)
+		return false;
+
+	quality = vc + max(vl, vr) + max(vu, vd);
+	if (quality < HIMAX_PEAK_QUALITY_MIN)
+		return false;
+
+	/* Keep only local maxima to avoid one finger expanding into many points. */
 	return true;
 }
 
 #define OFST 4
+static bool himax_far_enough(const struct input_mt_pos *a,
+			     const struct input_mt_pos *b,
+			     int min_delta)
+{
+	int dx = abs(a->x - b->x);
+	int dy = abs(a->y - b->y);
+
+	return dx >= min_delta || dy >= min_delta;
+}
+
 static void raw2rxtx(u16 *arr, int tx_max, int rx_max,
 		     struct input_mt_pos *pos, int *cnt)
 {
-	int i, j;
+	int i, j, k;
+	int near_idx;
+	int weakest_idx;
+	u16 strength[HIMAX_MAX_TOUCH] = {0};
+	u16 val;
 
 	*cnt = 0;
-	for (i = 0; i < tx_max; ++i)
-		for (j = 0; j < rx_max; ++j){
-			if (*cnt >= HIMAX_MAX_TOUCH) {
-				dump_frame((void *)arr - OFST, true);
-				pr_warn("%s: more then 10 contact points\n", __func__);
-				break;
+	for (i = 0; i < tx_max; ++i) {
+		for (j = 0; j < rx_max; ++j) {
+			struct input_mt_pos cand = {
+				.x = j,
+				.y = i,
+			};
+
+			if (!is_local_peak(arr, i, j))
+				continue;
+
+			val = dd2d(arr, i, j);
+			near_idx = -1;
+			for (k = 0; k < *cnt; k++) {
+				if (!himax_far_enough(&cand, &pos[k], HIMAX_TOUCH_SEPARATION_GRID)) {
+					near_idx = k;
+					break;
+				}
 			}
 
-			/* 水平方向为 rx, 垂直为 tx */
-			pos[*cnt].x = j;
-			pos[*cnt].y = i;
-			*cnt += is_new_point(arr, pos, *cnt);
+			/* Keep strongest one in a small neighborhood to avoid ghost duplicates. */
+			if (near_idx >= 0) {
+				if (val > strength[near_idx]) {
+					strength[near_idx] = val;
+					pos[near_idx] = cand;
+				}
+				continue;
+			}
+
+			if (*cnt < HIMAX_MAX_TOUCH) {
+				pos[*cnt] = cand;
+				strength[*cnt] = val;
+				(*cnt)++;
+				continue;
+			}
+
+			/* Replace the weakest tracked peak if current one is stronger. */
+			weakest_idx = 0;
+			for (k = 1; k < HIMAX_MAX_TOUCH; k++) {
+				if (strength[k] < strength[weakest_idx])
+					weakest_idx = k;
+			}
+
+			if (val > strength[weakest_idx]) {
+				strength[weakest_idx] = val;
+				pos[weakest_idx] = cand;
+			}
 		}
+	}
 }
 
 static void rxtx2xy(u16 *arr, struct input_mt_pos *pos, int cnt)
@@ -752,22 +798,123 @@ static void rxtx2xy(u16 *arr, struct input_mt_pos *pos, int cnt)
 	}
 }
 
+static inline int himax_dist2(const struct input_mt_pos *a,
+			      const struct himax_track *b)
+{
+	s32 dx = a->x - b->x;
+	s32 dy = a->y - b->y;
+
+	return dx * dx + dy * dy;
+}
+
+static void himax_track_contacts(struct himax_ts_data *ts,
+				 struct input_mt_pos *det,
+				 int det_cnt)
+{
+	bool det_used[HIMAX_MAX_TOUCH] = { false };
+	int i, j;
+
+	for (i = 0; i < HIMAX_MAX_TOUCH; i++) {
+		struct himax_track *trk = &ts->tracks[i];
+		int best_det = -1;
+		int best_dist2 = INT_MAX;
+
+		if (!trk->active)
+			continue;
+
+		for (j = 0; j < det_cnt; j++) {
+			int d2;
+
+			if (det_used[j])
+				continue;
+
+			d2 = himax_dist2(&det[j], trk);
+			if (d2 < best_dist2) {
+				best_dist2 = d2;
+				best_det = j;
+			}
+		}
+
+		if (best_det >= 0 && best_dist2 <= HIMAX_TRACK_MATCH_DIST2) {
+			/* Mild temporal smoothing to reduce noisy point jitter. */
+			trk->x = (trk->x * 3 + det[best_det].x) / 4;
+			trk->y = (trk->y * 3 + det[best_det].y) / 4;
+			trk->missed = 0;
+			if (trk->seen < U8_MAX)
+				trk->seen++;
+			det_used[best_det] = true;
+		} else {
+			trk->missed++;
+			if (trk->missed > HIMAX_TRACK_LOST_FRAMES)
+				trk->active = false;
+		}
+	}
+
+	for (j = 0; j < det_cnt; j++) {
+		struct himax_track *trk = NULL;
+
+		if (det_used[j])
+			continue;
+
+		for (i = 0; i < HIMAX_MAX_TOUCH; i++) {
+			if (!ts->tracks[i].active) {
+				trk = &ts->tracks[i];
+				break;
+			}
+		}
+		if (!trk)
+			continue;
+
+		trk->active = true;
+		trk->seen = 1;
+		trk->missed = 0;
+		trk->x = det[j].x;
+		trk->y = det[j].y;
+	}
+}
+
+static int himax_count_stable_tracks(struct himax_ts_data *ts)
+{
+	int i;
+	int cnt = 0;
+
+	for (i = 0; i < HIMAX_MAX_TOUCH; i++) {
+		if (ts->tracks[i].active && ts->tracks[i].seen >= HIMAX_NEW_TOUCH_DEBOUNCE)
+			cnt++;
+	}
+
+	return cnt;
+}
+
+static void himax_report_tracked_state(struct himax_ts_data *ts, bool report_on)
+{
+	int i;
+
+	for (i = 0; i < HIMAX_MAX_TOUCH; i++) {
+		bool on = report_on && ts->tracks[i].active &&
+			  ts->tracks[i].seen >= HIMAX_NEW_TOUCH_DEBOUNCE;
+
+		input_mt_slot(ts->input_dev, i);
+		input_mt_report_slot_state(ts->input_dev, MT_TOOL_FINGER, on);
+		if (!on)
+			continue;
+
+		touchscreen_report_pos(ts->input_dev, &ts->props,
+				       ts->tracks[i].x, ts->tracks[i].y, true);
+	}
+
+	input_mt_sync_frame(ts->input_dev);
+	input_sync(ts->input_dev);
+}
+
 static irqreturn_t himax_ts_thread(int irq, void *data)
 {
 	struct himax_ts_data *ts = data;
-	u16 *ptr = (void *)ts->xfer_buf + OFST;
+	u16 *ptr = (u16 *)(ts->event_buf + OFST);
 	struct input_mt_pos pos[HIMAX_MAX_TOUCH];
 	int cnt;
-
-	/*
-	 * 指定 若干毫秒 最多触发1次, 调试用可设置为 500, 1000 减少日志刷屏, 但必要时保持
-	 * 手指触摸以避免漏掉数据. 至少请设置为 10, 100hz 较为接近实际刷新率, 不设置会发生
-	 * 数据错误.
-	 */
-	if (time_before(jiffies, ts->update_time + msecs_to_jiffies(20))) {
-		drop_cnt++;
-		return IRQ_HANDLED;
-	}
+	int stable_cnt;
+	bool report_on = true;
 
 	if (hx83121a_gaokun_read_event_stack(ts)) {
 		dev_err(ts->dev, "failed to get touch data!\n");
@@ -785,15 +932,30 @@ static irqreturn_t himax_ts_thread(int irq, void *data)
 	}
 
 	rxtx2xy(ptr, pos, cnt);
+	himax_track_contacts(ts, pos, cnt);
+	stable_cnt = himax_count_stable_tracks(ts);
+
 	/* Not final results, touchscreen_report_pos will handle this (x-y swap, y invert) */
-	for (int i = 0; i < cnt; ++i) {
-		dev_dbg(ts->dev, "x-y %d: %d, %d\n", i, pos[i].x, pos[i].y);
+	for (int i = 0; i < HIMAX_MAX_TOUCH; ++i) {
+		if (!(ts->tracks[i].active && ts->tracks[i].seen >= HIMAX_NEW_TOUCH_DEBOUNCE))
+			continue;
+		dev_dbg(ts->dev, "slot %d x-y: %d, %d\n", i,
+			ts->tracks[i].x, ts->tracks[i].y);
+	}
+
+	if (stable_cnt > 0 && !ts->touch_active) {
+		ts->touch_start_frames++;
+		if (ts->touch_start_frames < HIMAX_TOUCH_START_DEBOUNCE)
+			report_on = false;
+		else
+			ts->touch_active = true;
+	} else if (stable_cnt == 0) {
+		ts->touch_start_frames = 0;
+		ts->touch_active = false;
 	}
 
 	/* 这里报告给系统的坐标数据可以通过 evtest 查看 */
-	himax_report_state(ts, pos, cnt);
-
-	ts->update_time = jiffies;
+	himax_report_tracked_state(ts, report_on);
 
 	return IRQ_HANDLED;
 }
@@ -908,7 +1070,7 @@ static int himax_mcu_power_on_init(struct himax_ts_data *ts)
 		return -EINVAL;
 	}
 
-	/* RawOut select set, must be 0xf6, fuck you huawei */
+	/* RawOut select for this panel configuration. */
 	data.dword = cpu_to_le32(0xf6);
 	ret = himax_mcu_register_write(ts, HIMAX_HX83121A_DSRAM_ADDR_RAW_OUT_SEL, data.byte, 4);
 	if (ret < 0) {
@@ -1007,8 +1169,13 @@ static int himax_spi_probe(struct spi_device *spi)
 	ts->spi = spi;
 	ts->spi_xfer_max_sz = HIMAX_HX83121A_FULL_STACK_SZ;
 	ts->xfer_buf_sz = ts->spi_xfer_max_sz;
+	ts->event_buf_sz = HIMAX_HX83121A_FULL_STACK_SZ;
 	ts->xfer_buf = devm_kzalloc(ts->dev, ts->xfer_buf_sz, GFP_KERNEL);
 	if (!ts->xfer_buf)
+		return -ENOMEM;
+
+	ts->event_buf = devm_kzalloc(ts->dev, ts->event_buf_sz, GFP_KERNEL);
+	if (!ts->event_buf)
 		return -ENOMEM;
 
 	spin_lock_init(&ts->irq_lock);
@@ -1071,3 +1238,5 @@ static struct spi_driver himax_spi_driver = {
 module_spi_driver(himax_spi_driver);
 
 MODULE_LICENSE("GPL");
+MODULE_AUTHOR("Pengyu Luo <mitltlatltl@gmail.com>");
+MODULE_DESCRIPTION("Himax HX83121A SPI touchscreen driver");

--- a/utils/img_pack.sh
+++ b/utils/img_pack.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -euo pipefail
 # =============================================================================
 # Filename: img_pack.sh
 # Purpose: To be filled
@@ -6,8 +7,58 @@
 # =============================================================================
 
 # libarchive-tools for bsdtar, qemu-user-static for emulation
-# parted for partion raw img, arch-install-scripts for arch-chroot, genfstab
-apt update && apt install -y zstd curl libarchive-tools qemu-user-static parted arch-install-scripts
+# parted for partitioning, arch-install-scripts for arch-chroot/genfstab
+apt update && apt install -y zstd curl libarchive-tools qemu-user-static parted arch-install-scripts dosfstools e2fsprogs
+
+CHROOT_DIR='alarm-chroot'
+IMAGE_SIZE="${IMAGE_SIZE:-6G}"
+ROOTFS_PAD_MIB="${ROOTFS_PAD_MIB:-512}"
+SHRINK_IMAGE="${SHRINK_IMAGE:-1}"
+ZSTD_LEVEL="${ZSTD_LEVEL:-15}"
+
+cleanup() {
+    local errexit_was_set=0
+    [[ $- == *e* ]] && errexit_was_set=1
+    set +e
+    if mountpoint -q "${CHROOT_DIR}/boot/efi" 2>/dev/null; then
+        umount "${CHROOT_DIR}/boot/efi"
+    fi
+    if mountpoint -q "${CHROOT_DIR}" 2>/dev/null; then
+        umount -R "${CHROOT_DIR}"
+    fi
+    if [[ -n "${LOOP_DEV:-}" ]] && losetup "${LOOP_DEV}" >/dev/null 2>&1; then
+        losetup -d "${LOOP_DEV}"
+    fi
+    (( errexit_was_set )) && set -e
+}
+
+shrink_rootfs_image() {
+    local block_count block_size fs_mib padded_fs_mib root_end_mib disk_size_bytes
+
+    e2fsck -fy "${LOOP_DEV}p2"
+    resize2fs -M "${LOOP_DEV}p2"
+
+    read -r block_count block_size < <(dumpe2fs -h "${LOOP_DEV}p2" 2>/dev/null | awk '
+        /Block count:/ {count=$3}
+        /Block size:/ {size=$3}
+        END {print count, size}
+    ')
+
+    fs_mib=$(( (block_count * block_size + 1024 * 1024 - 1) / (1024 * 1024) ))
+    padded_fs_mib=$(( fs_mib + ROOTFS_PAD_MIB ))
+    resize2fs "${LOOP_DEV}p2" "${padded_fs_mib}M"
+
+    root_end_mib=$(( 301 + padded_fs_mib ))
+    # Parted still asks for confirmation when shrinking a partition on some CI runners.
+    printf 'Yes\n' | parted ---pretend-input-tty "${LOOP_DEV}" unit MiB resizepart 2 "${root_end_mib}"
+
+    cleanup
+
+    disk_size_bytes=$(( (root_end_mib + 1) * 1024 * 1024 ))
+    truncate -s "${disk_size_bytes}" archlinuxarm.img
+}
+
+trap cleanup EXIT
 
 # handle binfmt_misc, https://access.redhat.com/solutions/1985633
 if grep -q 'binfmt_misc' /proc/mounts; then
@@ -16,31 +67,55 @@ else
     mount binfmt_misc -t binfmt_misc /proc/sys/fs/binfmt_misc
 fi
 
-echo 1 > /proc/sys/fs/binfmt_misc/status
-echo ':qemu-aarch64:M::\x7fELF\x02\x01\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x02\x00\xb7\x00:\xff\xff\xff\xff\xff\xff\xff\x00\xff\xff\xff\xff\xff\xff\xff\xff\xfe\xff\xff\xff:/usr/bin/qemu-aarch64-static:FP' > /proc/sys/fs/binfmt_misc/register
+if [[ -f /proc/sys/fs/binfmt_misc/status ]] && grep -qx 'disabled' /proc/sys/fs/binfmt_misc/status; then
+    echo 1 > /proc/sys/fs/binfmt_misc/status
+fi
+
+if [[ -e /proc/sys/fs/binfmt_misc/qemu-aarch64 ]]; then
+    echo "qemu-aarch64 binfmt already registered"
+else
+    echo ':qemu-aarch64:M::\x7fELF\x02\x01\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x02\x00\xb7\x00:\xff\xff\xff\xff\xff\xff\xff\x00\xff\xff\xff\xff\xff\xff\xff\xff\xfe\xff\xff\xff:/usr/bin/qemu-aarch64-static:FP' > /proc/sys/fs/binfmt_misc/register
+fi
+
+write_grub_cfg() {
+    cat > "${CHROOT_DIR}/boot/grub/grub.cfg" <<EOF
+set default=0
+set timeout=5
+
+menuentry 'Arch Linux (gaokun3 NVMe)' {
+    insmod part_gpt
+    insmod ext2
+    insmod gzio
+    search --no-floppy --fs-uuid --set=root ${ROOT_UUID}
+    devicetree /boot/sc8280xp-huawei-gaokun3.dtb
+    linux /boot/vmlinuz-linux-gaokun3 root=UUID=${ROOT_UUID} rw clk_ignore_unused pd_ignore_unused arm64.nopauth iommu.passthrough=0 iommu.strict=0 efi=noruntime modprobe.blacklist=msm loglevel=7 ignore_loglevel initcall_debug
+    initrd /boot/initramfs-linux-gaokun3.img
+}
+EOF
+}
 
 
-# first serval loop device are taken up
-LOOP_DEV='/dev/loop7'
+# Pick a free loop device instead of assuming a fixed one exists.
+LOOP_DEV="$(losetup -f)"
 
 # container setup
-dd of=archlinuxarm.img bs=1 seek=3G count=0
-losetup ${LOOP_DEV} archlinuxarm.img
+truncate -s "${IMAGE_SIZE}" archlinuxarm.img
+losetup -P ${LOOP_DEV} archlinuxarm.img
 parted ${LOOP_DEV} --script mklabel gpt
 parted ${LOOP_DEV} --script mkpart EFI fat32 1MiB 301MiB
 parted ${LOOP_DEV} --script set 1 boot on
 parted ${LOOP_DEV} --script mkpart ALARM ext4 301MiB 100%
 mkfs.fat -F32 ${LOOP_DEV}p1
 mkfs.ext4 ${LOOP_DEV}p2
+ROOT_UUID="$(blkid -s UUID -o value "${LOOP_DEV}p2")"
 
 # mount, extract rootfs and generate a mount table
-CHROOT_DIR='alarm-chroot'
-mkdir ${CHROOT_DIR}
+mkdir -p ${CHROOT_DIR}
 mount ${LOOP_DEV}p2 ${CHROOT_DIR}
 MIRROR_URL='http://fl.us.mirror.archlinuxarm.org'
-curl "$MIRROR_URL/os/ArchLinuxARM-aarch64-latest.tar.gz" > alarm.tar.gz
+curl -fsSL "$MIRROR_URL/os/ArchLinuxARM-aarch64-latest.tar.gz" -o alarm.tar.gz
 bsdtar -xpf alarm.tar.gz -C ${CHROOT_DIR}
-mkdir ${CHROOT_DIR}/boot/efi
+mkdir -p ${CHROOT_DIR}/boot/efi
 mount ${LOOP_DEV}p1 ${CHROOT_DIR}/boot/efi
 
 ###### dirty insert ######
@@ -55,6 +130,9 @@ cp /usr/bin/qemu-aarch64-static  ${CHROOT_DIR}/usr/bin/qemu-aarch64-static
 
 # enable ParallelDownloads
 sed -i 's/#ParallelDownloads = 5/ParallelDownloads = 4/' ${CHROOT_DIR}/etc/pacman.conf
+sed -i 's/^DownloadUser = .*/DownloadUser = root/' ${CHROOT_DIR}/etc/pacman.conf
+sed -i 's/^#DisableSandboxFilesystem/DisableSandboxFilesystem/' ${CHROOT_DIR}/etc/pacman.conf
+sed -i 's/^#DisableSandboxSyscalls/DisableSandboxSyscalls/' ${CHROOT_DIR}/etc/pacman.conf
 echo "Server = $MIRROR_URL"'/$arch/$repo' >> ${CHROOT_DIR}/etc/pacman.d/mirrorlist
 
 # add my repo to install kernel and firmware
@@ -83,42 +161,58 @@ arch-chroot ${CHROOT_DIR} sh -c 'pacman-key --init && pacman-key --populate arch
 curl https://raw.githubusercontent.com/right-0903/my_arch_auto_pack/refs/heads/main/keys/CA909D46CD1890BE.asc -o ${CHROOT_DIR}/root/CA909D46CD1890BE.asc
 arch-chroot ${CHROOT_DIR} sh -c 'pacman-key --add /root/CA909D46CD1890BE.asc && pacman-key --lsign-key CA909D46CD1890BE'
 
-# make life easier
-arch-chroot ${CHROOT_DIR} sh -c 'pacman -Rn linux-aarch64 --noconfirm'
+# Upgrade userland first. Defer the custom kernel until its firmware is in place.
+arch-chroot ${CHROOT_DIR} sh -c 'pacman -Syu efibootmgr grub wireless-regdb iwd btrfs-progs --noconfirm'
 
-# update and install something needed, then clean immediately because of container space
-arch-chroot ${CHROOT_DIR} sh -c 'pacman -Syu efibootmgr grub linux-firmware-qcom wireless-regdb --noconfirm && rm /var/cache/pacman/pkg/*'
+# The custom firmware package overlaps with upstream qcom/atheros firmware files.
+arch-chroot ${CHROOT_DIR} sh -c 'pacman -Rdd --noconfirm linux-firmware-atheros || true'
+arch-chroot ${CHROOT_DIR} sh -c 'pacman -Rdd --noconfirm linux-firmware-qcom || true'
+arch-chroot ${CHROOT_DIR} sh -c 'rm -rf /usr/lib/firmware/ath11k/WCN6855 /usr/lib/firmware/qca /usr/lib/firmware/qcom/a660_gmu.bin /usr/lib/firmware/qcom/a660_sqe.fw'
+arch-chroot ${CHROOT_DIR} sh -c "pacman -S linux-firmware-gaokun3 --noconfirm --overwrite '/usr/lib/firmware/ath11k/WCN6855/*,/usr/lib/firmware/qca/*,/usr/lib/firmware/qcom/a660_*'"
 
-arch-chroot ${CHROOT_DIR} sh -c 'pacman -S linux-gaokun3 linux-gaokun3-headers linux-firmware-gaokun3 --noconfirm'
+# Install the custom kernel only after the device-specific firmware is present.
+arch-chroot ${CHROOT_DIR} sh -c 'pacman -S linux-gaokun3 linux-gaokun3-headers --noconfirm'
 
-# add iwd to for wifi configuration, someone reported this, btrfs-progs for people using btrfs
-arch-chroot ${CHROOT_DIR} sh -c 'pacman -S iwd btrfs-progs --noconfirm'
+# Remove the stock kernel after the replacement is installed successfully.
+arch-chroot ${CHROOT_DIR} sh -c 'pacman -Rdd --noconfirm linux-aarch64 || true'
 
 # make a copy for this repo
-mv ${CHROOT_DIR}/var/cache/pacman/pkg/*.pkg.tar.zst .
+shopt -s nullglob
+pkg_cache=(${CHROOT_DIR}/var/cache/pacman/pkg/*.pkg.tar.*)
+if (( ${#pkg_cache[@]} )); then
+    mv "${pkg_cache[@]}" .
+fi
+shopt -u nullglob
+rm -f ${CHROOT_DIR}/var/cache/pacman/pkg/*
 
 # use early KMS for debugging, this would give us log in the initramfs stage.
-sed -i 's/^\(MODULES=(\)/\1\nsimpledrm\nphy-qcom-snps-femto-v2/' ${CHROOT_DIR}/etc/mkinitcpio-gaokun3.conf
+if [[ -f ${CHROOT_DIR}/etc/mkinitcpio-gaokun3.conf ]]; then
+    sed -i 's/^\(MODULES=(\)/\1\nsimpledrm\nphy-qcom-snps-femto-v2/' ${CHROOT_DIR}/etc/mkinitcpio-gaokun3.conf
+elif [[ -f ${CHROOT_DIR}/etc/mkinitcpio.conf ]]; then
+    sed -i 's/^\(MODULES=(\)/\1\nsimpledrm\nphy-qcom-snps-femto-v2/' ${CHROOT_DIR}/etc/mkinitcpio.conf
+fi
 arch-chroot ${CHROOT_DIR} sh -c 'mkinitcpio -P'
 
 # install grub
-arch-chroot ${CHROOT_DIR} sh -c "grub-install ${LOOP_DEV}p1"
+arch-chroot ${CHROOT_DIR} sh -c 'grub-install --target=arm64-efi --efi-directory=/boot/efi --bootloader-id=arch --no-nvram --recheck'
 
 # fix efi loading
-arch-chroot ${CHROOT_DIR} sh -c 'mkdir /boot/efi/EFI/Boot && cp /boot/efi/EFI/arch/grubaa64.efi /boot/efi/EFI/Boot/bootaa64.efi'
+arch-chroot ${CHROOT_DIR} sh -c 'mkdir -p /boot/efi/EFI/Boot && cp /boot/efi/EFI/arch/grubaa64.efi /boot/efi/EFI/Boot/BOOTAA64.EFI'
 
-# set kernel commandline parameters
-sed -i 's/GRUB_CMDLINE_LINUX=""/GRUB_CMDLINE_LINUX="clk_ignore_unused pd_ignore_unused arm64.nopauth iommu.passthrough=0 iommu.strict=0 pcie_aspm.policy=powersupersave efi=noruntime modprobe.blacklist=msm"/' ${CHROOT_DIR}/etc/default/grub
-sed -i 's/GRUB_CMDLINE_LINUX_DEFAULT="loglevel=3 quiet"/GRUB_CMDLINE_LINUX_DEFAULT="fbcon=rotate:1 loglevel=3"/' ${CHROOT_DIR}/etc/default/grub
-
-# generate the grub config
-arch-chroot ${CHROOT_DIR} 'update-grub'
+# Write the known-good configuration directly instead of relying on generic
+# templates, which may miss the board DTB or load unavailable arm64 modules.
+write_grub_cfg
 
 # do clean
-rm ${CHROOT_DIR}/usr/bin/qemu-aarch64-static ${CHROOT_DIR}/root/*
+rm -f ${CHROOT_DIR}/usr/bin/qemu-aarch64-static ${CHROOT_DIR}/root/*
 
-# umount
-umount -R ${CHROOT_DIR} && losetup -d ${LOOP_DEV}
+# Shrink the finished image before compressing it.
+if [[ "${SHRINK_IMAGE}" == "1" ]]; then
+    umount -R "${CHROOT_DIR}"
+    shrink_rootfs_image
+else
+    cleanup
+fi
 
-# compress, github release is limited to 2GB
-xz archlinuxarm.img
+# Compress with zstd to make CI finish faster. Use a single .zst artifact.
+zstd -T0 -"${ZSTD_LEVEL}" --rm archlinuxarm.img

--- a/utils/img_pack.sh
+++ b/utils/img_pack.sh
@@ -140,7 +140,7 @@ EOF
 arch-chroot ${CHROOT_DIR} sh -c 'pacman-key --init && pacman-key --populate archlinuxarm'
 
 # trust my key for my repo
-curl https://raw.githubusercontent.com/right-0903/my_arch_auto_pack/refs/heads/main/keys/CA909D46CD1890BE.asc -o ${CHROOT_DIR}/root/CA909D46CD1890BE.asc
+curl -fsSL https://raw.githubusercontent.com/right-0903/my_arch_auto_pack/main/keys/CA909D46CD1890BE.asc -o ${CHROOT_DIR}/root/CA909D46CD1890BE.asc
 arch-chroot ${CHROOT_DIR} sh -c 'pacman-key --add /root/CA909D46CD1890BE.asc && pacman-key --lsign-key CA909D46CD1890BE'
 
 # Remove the stock kernel and bundled firmware first so the expensive hooks

--- a/utils/img_pack.sh
+++ b/utils/img_pack.sh
@@ -15,6 +15,9 @@ IMAGE_SIZE="${IMAGE_SIZE:-6G}"
 ROOTFS_PAD_MIB="${ROOTFS_PAD_MIB:-512}"
 SHRINK_IMAGE="${SHRINK_IMAGE:-1}"
 ZSTD_LEVEL="${ZSTD_LEVEL:-15}"
+GRUB_CMDLINE_LINUX_BASE="${GRUB_CMDLINE_LINUX_BASE:-clk_ignore_unused pd_ignore_unused arm64.nopauth efi=noruntime}"
+GRUB_CMDLINE_LINUX_DEFAULT="${GRUB_CMDLINE_LINUX_DEFAULT:-fbcon=rotate:1 loglevel=3}"
+GRUB_CMDLINE_LINUX_EXTRA="${GRUB_CMDLINE_LINUX_EXTRA:-}"
 
 cleanup() {
     local errexit_was_set=0
@@ -78,6 +81,9 @@ else
 fi
 
 write_grub_cfg() {
+    local linux_cmdline
+    linux_cmdline="$(build_linux_cmdline)"
+
     cat > "${CHROOT_DIR}/boot/grub/grub.cfg" <<EOF
 set default=0
 set timeout=5
@@ -88,10 +94,36 @@ menuentry 'Arch Linux (gaokun3 NVMe)' {
     insmod gzio
     search --no-floppy --fs-uuid --set=root ${ROOT_UUID}
     devicetree /boot/sc8280xp-huawei-gaokun3.dtb
-    linux /boot/vmlinuz-linux-gaokun3 root=UUID=${ROOT_UUID} rw clk_ignore_unused pd_ignore_unused arm64.nopauth iommu.passthrough=0 iommu.strict=0 efi=noruntime modprobe.blacklist=msm loglevel=7 ignore_loglevel initcall_debug
+    linux /boot/vmlinuz-linux-gaokun3 ${linux_cmdline}
     initrd /boot/initramfs-linux-gaokun3.img
 }
 EOF
+}
+
+build_linux_cmdline() {
+    local -a args
+
+    args=("root=UUID=${ROOT_UUID}" "rw")
+
+    append_cmdline_words "${GRUB_CMDLINE_LINUX_BASE}" args
+
+    append_cmdline_words "${GRUB_CMDLINE_LINUX_DEFAULT}" args
+    append_cmdline_words "${GRUB_CMDLINE_LINUX_EXTRA}" args
+
+    printf '%s\n' "${args[*]}"
+}
+
+append_cmdline_words() {
+    local value="$1"
+    local -n target_ref="$2"
+    local -a words
+
+    if [[ -z "${value}" ]]; then
+        return
+    fi
+
+    read -r -a words <<< "${value}"
+    target_ref+=("${words[@]}")
 }
 
 

--- a/utils/img_pack.sh
+++ b/utils/img_pack.sh
@@ -8,6 +8,7 @@ set -euo pipefail
 
 # libarchive-tools for bsdtar, qemu-user-static for emulation
 # parted for partitioning, arch-install-scripts for arch-chroot/genfstab
+# dosfstools for mkfs.fat, e2fsprogs for resize2fs/e2fsck/dumpe2fs
 apt update && apt install -y zstd curl libarchive-tools qemu-user-static parted arch-install-scripts dosfstools e2fsprogs
 
 CHROOT_DIR='alarm-chroot'
@@ -15,9 +16,6 @@ IMAGE_SIZE="${IMAGE_SIZE:-6G}"
 ROOTFS_PAD_MIB="${ROOTFS_PAD_MIB:-512}"
 SHRINK_IMAGE="${SHRINK_IMAGE:-1}"
 ZSTD_LEVEL="${ZSTD_LEVEL:-15}"
-GRUB_CMDLINE_LINUX_BASE="${GRUB_CMDLINE_LINUX_BASE:-clk_ignore_unused pd_ignore_unused arm64.nopauth efi=noruntime}"
-GRUB_CMDLINE_LINUX_DEFAULT="${GRUB_CMDLINE_LINUX_DEFAULT:-fbcon=rotate:1 loglevel=3}"
-GRUB_CMDLINE_LINUX_EXTRA="${GRUB_CMDLINE_LINUX_EXTRA:-}"
 
 cleanup() {
     local errexit_was_set=0
@@ -80,53 +78,6 @@ else
     echo ':qemu-aarch64:M::\x7fELF\x02\x01\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x02\x00\xb7\x00:\xff\xff\xff\xff\xff\xff\xff\x00\xff\xff\xff\xff\xff\xff\xff\xff\xfe\xff\xff\xff:/usr/bin/qemu-aarch64-static:FP' > /proc/sys/fs/binfmt_misc/register
 fi
 
-write_grub_cfg() {
-    local linux_cmdline
-    linux_cmdline="$(build_linux_cmdline)"
-
-    cat > "${CHROOT_DIR}/boot/grub/grub.cfg" <<EOF
-set default=0
-set timeout=5
-
-menuentry 'Arch Linux (gaokun3 NVMe)' {
-    insmod part_gpt
-    insmod ext2
-    insmod gzio
-    search --no-floppy --fs-uuid --set=root ${ROOT_UUID}
-    devicetree /boot/sc8280xp-huawei-gaokun3.dtb
-    linux /boot/vmlinuz-linux-gaokun3 ${linux_cmdline}
-    initrd /boot/initramfs-linux-gaokun3.img
-}
-EOF
-}
-
-build_linux_cmdline() {
-    local -a args
-
-    args=("root=UUID=${ROOT_UUID}" "rw")
-
-    append_cmdline_words "${GRUB_CMDLINE_LINUX_BASE}" args
-
-    append_cmdline_words "${GRUB_CMDLINE_LINUX_DEFAULT}" args
-    append_cmdline_words "${GRUB_CMDLINE_LINUX_EXTRA}" args
-
-    printf '%s\n' "${args[*]}"
-}
-
-append_cmdline_words() {
-    local value="$1"
-    local -n target_ref="$2"
-    local -a words
-
-    if [[ -z "${value}" ]]; then
-        return
-    fi
-
-    read -r -a words <<< "${value}"
-    target_ref+=("${words[@]}")
-}
-
-
 # Pick a free loop device instead of assuming a fixed one exists.
 LOOP_DEV="$(losetup -f)"
 
@@ -139,7 +90,6 @@ parted ${LOOP_DEV} --script set 1 boot on
 parted ${LOOP_DEV} --script mkpart ALARM ext4 301MiB 100%
 mkfs.fat -F32 ${LOOP_DEV}p1
 mkfs.ext4 ${LOOP_DEV}p2
-ROOT_UUID="$(blkid -s UUID -o value "${LOOP_DEV}p2")"
 
 # mount, extract rootfs and generate a mount table
 mkdir -p ${CHROOT_DIR}
@@ -193,20 +143,17 @@ arch-chroot ${CHROOT_DIR} sh -c 'pacman-key --init && pacman-key --populate arch
 curl https://raw.githubusercontent.com/right-0903/my_arch_auto_pack/refs/heads/main/keys/CA909D46CD1890BE.asc -o ${CHROOT_DIR}/root/CA909D46CD1890BE.asc
 arch-chroot ${CHROOT_DIR} sh -c 'pacman-key --add /root/CA909D46CD1890BE.asc && pacman-key --lsign-key CA909D46CD1890BE'
 
-# Upgrade userland first. Defer the custom kernel until its firmware is in place.
-arch-chroot ${CHROOT_DIR} sh -c 'pacman -Syu efibootmgr grub wireless-regdb iwd btrfs-progs --noconfirm'
-
-# The custom firmware package overlaps with upstream qcom/atheros firmware files.
+# Remove the stock kernel and bundled firmware first so the expensive hooks
+# only run once for the final gaokun3 package set.
+arch-chroot ${CHROOT_DIR} sh -c 'pacman -Rdd --noconfirm linux-aarch64 || true'
+arch-chroot ${CHROOT_DIR} sh -c 'pacman -Rdd --noconfirm linux-aarch64-headers || true'
+arch-chroot ${CHROOT_DIR} sh -c 'pacman -Rdd --noconfirm linux-firmware || true'
 arch-chroot ${CHROOT_DIR} sh -c 'pacman -Rdd --noconfirm linux-firmware-atheros || true'
 arch-chroot ${CHROOT_DIR} sh -c 'pacman -Rdd --noconfirm linux-firmware-qcom || true'
-arch-chroot ${CHROOT_DIR} sh -c 'rm -rf /usr/lib/firmware/ath11k/WCN6855 /usr/lib/firmware/qca /usr/lib/firmware/qcom/a660_gmu.bin /usr/lib/firmware/qcom/a660_sqe.fw'
-arch-chroot ${CHROOT_DIR} sh -c "pacman -S linux-firmware-gaokun3 --noconfirm --overwrite '/usr/lib/firmware/ath11k/WCN6855/*,/usr/lib/firmware/qca/*,/usr/lib/firmware/qcom/a660_*'"
+arch-chroot ${CHROOT_DIR} sh -c 'rm -rf /usr/lib/firmware/*'
 
-# Install the custom kernel only after the device-specific firmware is present.
-arch-chroot ${CHROOT_DIR} sh -c 'pacman -S linux-gaokun3 linux-gaokun3-headers --noconfirm'
-
-# Remove the stock kernel after the replacement is installed successfully.
-arch-chroot ${CHROOT_DIR} sh -c 'pacman -Rdd --noconfirm linux-aarch64 || true'
+# Install final packages in one transaction.
+arch-chroot ${CHROOT_DIR} sh -c 'pacman -Syu efibootmgr grub wireless-regdb iwd btrfs-progs linux-gaokun3 linux-gaokun3-headers linux-firmware-gaokun3 --noconfirm'
 
 # make a copy for this repo
 shopt -s nullglob
@@ -217,23 +164,18 @@ fi
 shopt -u nullglob
 rm -f ${CHROOT_DIR}/var/cache/pacman/pkg/*
 
-# use early KMS for debugging, this would give us log in the initramfs stage.
-if [[ -f ${CHROOT_DIR}/etc/mkinitcpio-gaokun3.conf ]]; then
-    sed -i 's/^\(MODULES=(\)/\1\nsimpledrm\nphy-qcom-snps-femto-v2/' ${CHROOT_DIR}/etc/mkinitcpio-gaokun3.conf
-elif [[ -f ${CHROOT_DIR}/etc/mkinitcpio.conf ]]; then
-    sed -i 's/^\(MODULES=(\)/\1\nsimpledrm\nphy-qcom-snps-femto-v2/' ${CHROOT_DIR}/etc/mkinitcpio.conf
-fi
-arch-chroot ${CHROOT_DIR} sh -c 'mkinitcpio -P'
-
 # install grub
 arch-chroot ${CHROOT_DIR} sh -c 'grub-install --target=arm64-efi --efi-directory=/boot/efi --bootloader-id=arch --no-nvram --recheck'
 
 # fix efi loading
 arch-chroot ${CHROOT_DIR} sh -c 'mkdir -p /boot/efi/EFI/Boot && cp /boot/efi/EFI/arch/grubaa64.efi /boot/efi/EFI/Boot/BOOTAA64.EFI'
 
-# Write the known-good configuration directly instead of relying on generic
-# templates, which may miss the board DTB or load unavailable arm64 modules.
-write_grub_cfg
+# set kernel commandline parameters
+sed -i 's/GRUB_CMDLINE_LINUX=""/GRUB_CMDLINE_LINUX="clk_ignore_unused pd_ignore_unused arm64.nopauth iommu.passthrough=0 iommu.strict=0 pcie_aspm.policy=powersupersave efi=noruntime modprobe.blacklist=msm"/' ${CHROOT_DIR}/etc/default/grub
+sed -i 's/GRUB_CMDLINE_LINUX_DEFAULT="loglevel=3 quiet"/GRUB_CMDLINE_LINUX_DEFAULT="fbcon=rotate:1 loglevel=3"/' ${CHROOT_DIR}/etc/default/grub
+
+# generate the grub config
+arch-chroot ${CHROOT_DIR} sh -c 'update-grub'
 
 # do clean
 rm -f ${CHROOT_DIR}/usr/bin/qemu-aarch64-static ${CHROOT_DIR}/root/*


### PR DESCRIPTION
Hi,

First of all, thank you for all the work you have done for Linux support on this device. Your repository is the main reason I was able to get Linux running on my Huawei MateBook E Go, and I really appreciate the amount of reverse-engineering and integration work that went into it.

I have been using my own fork on this machine and made a few improvements that seem stable on my setup. I would like to upstream them here.

The main changes are:

- UCSI / USB-C / DisplayPort Alt Mode
  - reworked the UCSI boot-time registration flow to avoid early EC/UCSI races
  - fixed initialization details such as connector/port handling and `num_ports`
  - changed the notifier path so missing USB follow-up events no longer block the EC notifier
  - handled per-port updates more robustly instead of assuming a single-port change
  - added Type-C switch/mux handling and HPD replay logic for DP Alt Mode
  - on my machine this fixes the unstable UCSI behavior and makes higher-bandwidth external display modes work much more reliably; I can now use up to 2K@140Hz on an external display

- Himax touchscreen
  - significantly improved the SPI touchscreen driver state handling
  - added more reliable multi-touch tracking instead of the earlier provisional behavior
  - cleaned up missed-frame handling so stale contacts are dropped correctly
  - added deferred controller reinitialization across boot, suspend/resume, and input reopen, which made the touchscreen much more reliable in real use
  - multi-touch is now close to fully usable on my device
  - pen/stylus support is still not implemented

- GRUB / boot configuration
  - simplified the GRUB setup and removed some unnecessary parameters
  - switched the image build flow to generate a known-good `grub.cfg` directly for this device
  - the resulting configuration is smaller and is currently working correctly on my MateBook E Go

- Image/build script fixes
  - fixed the image packing/build script so it works reliably again
  - improved loop device allocation, cleanup, firmware installation order, bootloader setup, and final image shrinking/compression
  - also fixed the DKMS Makefile battery object name so the module build works correctly again

Thanks to @TheUnknownThing for helping with the build-script side and for the `num_ports` fix.

If you prefer, I can also split this into smaller PRs (for example: UCSI/DP, touchscreen, and image/GRUB changes), but I wanted to first send the working set that I am currently using on real hardware.

Thanks again for all your work on this device.