### PR TITLE
media: add SC8280XP Venus patch set

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -70,7 +70,7 @@ Refer to [this](https://github.com/jhovold/linux/wiki/X13s) as well. If you want
 | USB | works | |
 | USB-PD | works | fast charging(45W+) supported with UCSI EC driver |
 | USB-C DisplayPort Alt Mode | works | it may be broken nowadays (untested since ~6.14) |
-| Video acceleration | untested | see [below](#Video-acceleration) |
+| Video acceleration | works | see [below](#Video-acceleration) |
 | Virtualisation | untested | see [here](https://github.com/TravMurav/slbounce) |
 | Volumn keys | works | |
 | Watchdog | partial | One in sc8280xp works, another in EC not |
@@ -206,7 +206,8 @@ SLPI(Sensor Low Power Island), [more details](https://lore.kernel.org/linux-devi
 [Fastrpc reference](https://github.com/qualcomm/fastrpc).
 
 ## Video acceleration
-The firmware can be loaded. It supports v4l2_m2m, never tested it.
+Hardware video acceleration is supported via the Qualcomm Venus engine using the `v4l2m2m` API. Examples of usage:
+- **mpv**: `mpv --hwdec=v4l2m2m-copy <video>`
 
 ## Wi-Fi
 Use [the script](https://github.com/qca/qca-swiss-army-knife/blob/master/tools/scripts/ath11k/ath11k-bdencoder),

--- a/patch sets/media/0013-media-dt-bindings-Document-SC8280XP-SM8350-Venus.patch
+++ b/patch sets/media/0013-media-dt-bindings-Document-SC8280XP-SM8350-Venus.patch
@@ -1,0 +1,176 @@
+From 2ce317909747301ea565318bdd87f71989b139f0 Mon Sep 17 00:00:00 2001
+From: Konrad Dybcio <konrad.dybcio@linaro.org>
+Date: Fri, 4 Aug 2023 22:09:08 +0200
+Subject: [PATCH] media: dt-bindings: Document SC8280XP/SM8350 Venus
+
+Both of these SoCs implement an IRIS2 block, with SC8280XP being able
+to clock it a bit higher.
+
+Document it.
+
+Signed-off-by: Konrad Dybcio <konrad.dybcio@linaro.org>
+Link: https://lore.kernel.org/r/20230731-topic-8280_venus-v1-1-8c8bbe1983a5@linaro.org
+Signed-off-by: Johan Hovold <johan+linaro@kernel.org>
+---
+ .../bindings/media/qcom,sm8350-venus.yaml     | 149 ++++++++++++++++++
+ 1 file changed, 149 insertions(+)
+ create mode 100644 Documentation/devicetree/bindings/media/qcom,sm8350-venus.yaml
+
+diff --git a/Documentation/devicetree/bindings/media/qcom,sm8350-venus.yaml b/Documentation/devicetree/bindings/media/qcom,sm8350-venus.yaml
+new file mode 100644
+index 000000000000..8a31bce27c18
+--- /dev/null
++++ b/Documentation/devicetree/bindings/media/qcom,sm8350-venus.yaml
+@@ -0,0 +1,149 @@
++# SPDX-License-Identifier: (GPL-2.0 OR BSD-2-Clause)
++%YAML 1.2
++---
++$id: http://devicetree.org/schemas/media/qcom,sm8350-venus.yaml#
++$schema: http://devicetree.org/meta-schemas/core.yaml#
++
++title: Qualcomm SM8350 Venus video encode and decode accelerators
++
++maintainers:
++  - Konrad Dybcio <konradybcio@kernel.org>
++
++description: |
++  The Venus Iris2 IP is a video encode and decode accelerator present
++  on Qualcomm platforms
++
++allOf:
++  - $ref: qcom,venus-common.yaml#
++
++properties:
++  compatible:
++    enum:
++      - qcom,sc8280xp-venus
++      - qcom,sm8350-venus
++
++  clocks:
++    maxItems: 3
++
++  clock-names:
++    items:
++      - const: iface
++      - const: core
++      - const: vcodec0_core
++
++  resets:
++    maxItems: 1
++
++  reset-names:
++    items:
++      - const: core
++
++  power-domains:
++    maxItems: 3
++
++  power-domain-names:
++    items:
++      - const: venus
++      - const: vcodec0
++      - const: mx
++
++  interconnects:
++    maxItems: 3
++
++  interconnect-names:
++    items:
++      - const: cpu-cfg
++      - const: video-mem
++      - const: video-llcc
++
++  operating-points-v2: true
++  opp-table:
++    type: object
++
++  iommus:
++    maxItems: 1
++
++  video-decoder:
++    type: object
++
++    properties:
++      compatible:
++        const: venus-decoder
++
++    required:
++      - compatible
++
++    additionalProperties: false
++
++  video-encoder:
++    type: object
++
++    properties:
++      compatible:
++        const: venus-encoder
++
++    required:
++      - compatible
++
++    additionalProperties: false
++
++required:
++  - compatible
++  - power-domain-names
++  - iommus
++  - video-decoder
++  - video-encoder
++
++unevaluatedProperties: false
++
++examples:
++  - |
++    #include <dt-bindings/interrupt-controller/arm-gic.h>
++    #include <dt-bindings/clock/qcom,gcc-sm8350.h>
++    #include <dt-bindings/clock/qcom,sm8350-videocc.h>
++    #include <dt-bindings/interconnect/qcom,sm8350.h>
++    #include <dt-bindings/power/qcom-rpmpd.h>
++
++    venus: video-codec@aa00000 {
++        compatible = "qcom,sm8350-venus";
++        reg = <0x0aa00000 0x100000>;
++        interrupts = <GIC_SPI 174 IRQ_TYPE_LEVEL_HIGH>;
++
++        clocks = <&gcc GCC_VIDEO_AXI0_CLK>,
++                 <&videocc VIDEO_CC_MVS0C_CLK>,
++                 <&videocc VIDEO_CC_MVS0_CLK>;
++        clock-names = "iface",
++                      "core",
++                      "vcodec0_core";
++
++        resets = <&gcc GCC_VIDEO_AXI0_CLK_ARES>;
++        reset-names = "core";
++
++        power-domains = <&videocc MVS0C_GDSC>,
++                        <&videocc MVS0_GDSC>,
++                        <&rpmhpd SM8350_MX>;
++        power-domain-names = "venus",
++                             "vcodec0",
++                             "mx";
++
++        interconnects = <&gem_noc MASTER_APPSS_PROC 0 &config_noc SLAVE_VENUS_CFG 0>,
++                        <&mmss_noc MASTER_VIDEO_P0 0 &mc_virt SLAVE_EBI1 0>,
++                        <&mmss_noc MASTER_VIDEO_P0 0 &gem_noc SLAVE_LLCC 0>;
++        interconnect-names = "cpu-cfg",
++                             "video-mem",
++                             "video-llcc";
++
++        operating-points-v2 = <&venus_opp_table>;
++        iommus = <&apps_smmu 0x2100 0x400>;
++        memory-region = <&pil_video_mem>;
++
++        status = "disabled";
++
++        video-decoder {
++            compatible = "venus-decoder";
++        };
++
++        video-encoder {
++            compatible = "venus-encoder";
++        };
++    };
+-- 
+2.43.0
+

--- a/patch sets/media/0014-media-venus-core-Remove-trailing-commas-from-of-match-entries.patch
+++ b/patch sets/media/0014-media-venus-core-Remove-trailing-commas-from-of-match-entries.patch
@@ -1,0 +1,53 @@
+From e375d916df946623f751a0611004b9a8c8a72194 Mon Sep 17 00:00:00 2001
+From: Konrad Dybcio <konrad.dybcio@linaro.org>
+Date: Fri, 4 Aug 2023 22:09:09 +0200
+Subject: [PATCH] media: venus: core: Remove trailing commas from of match
+ entries
+
+Even though it has zero effect on functionality, remove them for coherency
+with other drivers.
+
+Signed-off-by: Konrad Dybcio <konrad.dybcio@linaro.org>
+Reviewed-by: Bryan O'Donoghue <bryan.odonoghue@linaro.org>
+Link: https://lore.kernel.org/r/20230731-topic-8280_venus-v1-2-8c8bbe1983a5@linaro.org
+Signed-off-by: Johan Hovold <johan+linaro@kernel.org>
+---
+ drivers/media/platform/qcom/venus/core.c | 22 +++++++++++-----------
+ 1 file changed, 11 insertions(+), 11 deletions(-)
+
+diff --git a/drivers/media/platform/qcom/venus/core.c b/drivers/media/platform/qcom/venus/core.c
+index 7e639760c41d..67b69a3c581f 100644
+--- a/drivers/media/platform/qcom/venus/core.c
++++ b/drivers/media/platform/qcom/venus/core.c
+@@ -1120,17 +1120,17 @@ static const struct venus_resources qcm2290_res = {
+ };
+ 
+ static const struct of_device_id venus_dt_match[] = {
+-	{ .compatible = "qcom,msm8916-venus", .data = &msm8916_res, },
+-	{ .compatible = "qcom,msm8996-venus", .data = &msm8996_res, },
+-	{ .compatible = "qcom,msm8998-venus", .data = &msm8998_res, },
+-	{ .compatible = "qcom,qcm2290-venus", .data = &qcm2290_res, },
+-	{ .compatible = "qcom,sc7180-venus", .data = &sc7180_res, },
+-	{ .compatible = "qcom,sc7280-venus", .data = &sc7280_res, },
+-	{ .compatible = "qcom,sdm660-venus", .data = &sdm660_res, },
+-	{ .compatible = "qcom,sdm845-venus", .data = &sdm845_res, },
+-	{ .compatible = "qcom,sdm845-venus-v2", .data = &sdm845_res_v2, },
+-	{ .compatible = "qcom,sm8250-venus", .data = &sm8250_res, },
+-	{ }
++	{ .compatible = "qcom,msm8916-venus", .data = &msm8916_res },
++	{ .compatible = "qcom,msm8996-venus", .data = &msm8996_res },
++	{ .compatible = "qcom,msm8998-venus", .data = &msm8998_res },
++	{ .compatible = "qcom,qcm2290-venus", .data = &qcm2290_res },
++	{ .compatible = "qcom,sc7180-venus", .data = &sc7180_res },
++	{ .compatible = "qcom,sc7280-venus", .data = &sc7280_res },
++	{ .compatible = "qcom,sdm660-venus", .data = &sdm660_res },
++	{ .compatible = "qcom,sdm845-venus", .data = &sdm845_res },
++	{ .compatible = "qcom,sdm845-venus-v2", .data = &sdm845_res_v2 },
++	{ .compatible = "qcom,sm8250-venus", .data = &sm8250_res },
++	{}
+ };
+ MODULE_DEVICE_TABLE(of, venus_dt_match);
+ 
+-- 
+2.43.0
+

--- a/patch sets/media/0015-media-venus-hfi_venus-Support-only-updating-certain-bits-with-presets.patch
+++ b/patch sets/media/0015-media-venus-hfi_venus-Support-only-updating-certain-bits-with-presets.patch
@@ -1,0 +1,60 @@
+From e4162c488ac76e2ab771237f67ac9808be5ea0b5 Mon Sep 17 00:00:00 2001
+From: Konrad Dybcio <konrad.dybcio@linaro.org>
+Date: Fri, 4 Aug 2023 22:09:10 +0200
+Subject: [PATCH] media: venus: hfi_venus: Support only updating certain bits
+ with presets
+
+On some platforms (like SM8350) we're expected to only touch certain bits
+(such as 0 and 4 corresponding to mask 0x11). Add support for doing so.
+
+Signed-off-by: Konrad Dybcio <konrad.dybcio@linaro.org>
+Reviewed-by: Bryan O'Donoghue <bryan.odonoghue@linaro.org>
+Link: https://lore.kernel.org/r/20230731-topic-8280_venus-v1-3-8c8bbe1983a5@linaro.org
+Signed-off-by: Johan Hovold <johan+linaro@kernel.org>
+---
+ drivers/media/platform/qcom/venus/core.h      |  1 +
+ drivers/media/platform/qcom/venus/hfi_venus.c | 15 ++++++++++++---
+ 2 files changed, 13 insertions(+), 3 deletions(-)
+
+diff --git a/drivers/media/platform/qcom/venus/core.h b/drivers/media/platform/qcom/venus/core.h
+index 7506f5d0f609..f680c74049a0 100644
+--- a/drivers/media/platform/qcom/venus/core.h
++++ b/drivers/media/platform/qcom/venus/core.h
+@@ -40,6 +40,7 @@ struct freq_tbl {
+ struct reg_val {
+ 	u32 reg;
+ 	u32 value;
++	u32 mask;
+ };
+ 
+ struct bw_tbl {
+diff --git a/drivers/media/platform/qcom/venus/hfi_venus.c b/drivers/media/platform/qcom/venus/hfi_venus.c
+index bd82066bb6e7..9f76a4fe5d6f 100644
+--- a/drivers/media/platform/qcom/venus/hfi_venus.c
++++ b/drivers/media/platform/qcom/venus/hfi_venus.c
+@@ -369,10 +369,19 @@ static void venus_set_registers(struct venus_hfi_device *hdev)
+ 	const struct venus_resources *res = hdev->core->res;
+ 	const struct reg_val *tbl = res->reg_tbl;
+ 	unsigned int count = res->reg_tbl_size;
+-	unsigned int i;
++	unsigned int i, val;
++
++	for (i = 0; i < count; i++) {
++		val = tbl[i].value;
+ 
+-	for (i = 0; i < count; i++)
+-		writel(tbl[i].value, hdev->core->base + tbl[i].reg);
++		/* In some cases, we only want to update certain bits */
++		if (tbl[i].mask) {
++			val = readl(hdev->core->base + tbl[i].reg);
++			val = (val & ~tbl[i].mask) | (tbl[i].value & tbl[i].mask);
++		}
++
++		writel(val, hdev->core->base + tbl[i].reg);
++	}
+ }
+ 
+ static void venus_soft_int(struct venus_hfi_device *hdev)
+-- 
+2.43.0
+

--- a/patch sets/media/0016-media-platform-venus-Add-optional-LLCC-path.patch
+++ b/patch sets/media/0016-media-platform-venus-Add-optional-LLCC-path.patch
@@ -1,0 +1,112 @@
+From d88860974de160f4ff8ee92c738b0f08471dff55 Mon Sep 17 00:00:00 2001
+From: Konrad Dybcio <konrad.dybcio@linaro.org>
+Date: Fri, 4 Aug 2023 22:09:11 +0200
+Subject: [PATCH] media: platform: venus: Add optional LLCC path
+
+Some newer SoCs (such as SM8350) have a third interconnect path. Add
+it and make it optional.
+
+Signed-off-by: Konrad Dybcio <konrad.dybcio@linaro.org>
+Link: https://lore.kernel.org/r/20230731-topic-8280_venus-v1-4-8c8bbe1983a5@linaro.org
+Signed-off-by: Johan Hovold <johan+linaro@kernel.org>
+---
+ drivers/media/platform/qcom/venus/core.c      | 19 +++++++++++++++++++
+ drivers/media/platform/qcom/venus/core.h      |  3 +++
+ .../media/platform/qcom/venus/pm_helpers.c    |  3 +++
+ 3 files changed, 25 insertions(+)
+
+diff --git a/drivers/media/platform/qcom/venus/core.c b/drivers/media/platform/qcom/venus/core.c
+index 67b69a3c581f..1f42792f0338 100644
+--- a/drivers/media/platform/qcom/venus/core.c
++++ b/drivers/media/platform/qcom/venus/core.c
+@@ -398,6 +398,15 @@ static int venus_probe(struct platform_device *pdev)
+ 	if (IS_ERR(core->cpucfg_path))
+ 		return PTR_ERR(core->cpucfg_path);
+ 
++	core->llcc_path = devm_of_icc_get(dev, "video-llcc");
++	if (IS_ERR(core->llcc_path)) {
++		/* LLCC path is optional */
++		if (PTR_ERR(core->llcc_path) == -ENODATA)
++			core->llcc_path = NULL;
++		else
++			return PTR_ERR(core->llcc_path);
++	}
++
+ 	core->irq = platform_get_irq(pdev, 0);
+ 	if (core->irq < 0)
+ 		return core->irq;
+@@ -594,12 +603,18 @@ static __maybe_unused int venus_runtime_suspend(struct device *dev)
+ 	if (ret)
+ 		goto err_cpucfg_path;
+ 
++	ret = icc_set_bw(core->llcc_path, 0, 0);
++	if (ret)
++		goto err_llcc_path;
++
+ 	ret = icc_set_bw(core->video_path, 0, 0);
+ 	if (ret)
+ 		goto err_video_path;
+ 
+ 	return ret;
+ 
++err_llcc_path:
++	icc_set_bw(core->video_path, kbps_to_icc(20000), 0);
+ err_video_path:
+ 	icc_set_bw(core->cpucfg_path, kbps_to_icc(1000), 0);
+ err_cpucfg_path:
+@@ -639,6 +654,10 @@ static __maybe_unused int venus_runtime_resume(struct device *dev)
+ 	if (ret)
+ 		return ret;
+ 
++	ret = icc_set_bw(core->llcc_path, kbps_to_icc(20000), 0);
++	if (ret)
++		return ret;
++
+ 	ret = icc_set_bw(core->cpucfg_path, kbps_to_icc(1000), 0);
+ 	if (ret)
+ 		return ret;
+diff --git a/drivers/media/platform/qcom/venus/core.h b/drivers/media/platform/qcom/venus/core.h
+index f680c74049a0..bd89a5d58baf 100644
+--- a/drivers/media/platform/qcom/venus/core.h
++++ b/drivers/media/platform/qcom/venus/core.h
+@@ -73,6 +73,7 @@ struct venus_resources {
+ 	unsigned int bw_tbl_enc_size;
+ 	const struct bw_tbl *bw_tbl_dec;
+ 	unsigned int bw_tbl_dec_size;
++	bool has_llcc_path;
+ 	const struct reg_val *reg_tbl;
+ 	unsigned int reg_tbl_size;
+ 	const struct hfi_ubwc_config *ubwc_conf;
+@@ -145,6 +146,7 @@ struct venus_format {
+  * @vcodec1_clks: an array of vcodec1 struct clk pointers
+  * @video_path: an interconnect handle to video to/from memory path
+  * @cpucfg_path: an interconnect handle to cpu configuration path
++ * @llcc_path: an interconnect handle to video to/from llcc path
+  * @pmdomains:	a pointer to a list of pmdomains
+  * @opp_pmdomain: an OPP power-domain
+  * @resets: an array of reset signals
+@@ -199,6 +201,7 @@ struct venus_core {
+ 	struct clk *vcodec1_clks[VIDC_VCODEC_CLKS_NUM_MAX];
+ 	struct icc_path *video_path;
+ 	struct icc_path *cpucfg_path;
++	struct icc_path *llcc_path;
+ 	struct dev_pm_domain_list *pmdomains;
+ 	struct dev_pm_domain_list *opp_pmdomain;
+ 	struct reset_control *resets[VIDC_RESETS_NUM_MAX];
+diff --git a/drivers/media/platform/qcom/venus/pm_helpers.c b/drivers/media/platform/qcom/venus/pm_helpers.c
+index f0269524ac70..bf9eddf74ee5 100644
+--- a/drivers/media/platform/qcom/venus/pm_helpers.c
++++ b/drivers/media/platform/qcom/venus/pm_helpers.c
+@@ -243,6 +243,9 @@ static int load_scale_bw(struct venus_core *core)
+ 	dev_dbg(core->dev, VDBGL "total: avg_bw: %u, peak_bw: %u\n",
+ 		total_avg, total_peak);
+ 
++	if (core->res->has_llcc_path)
++		icc_set_bw(core->llcc_path, total_avg, total_peak);
++
+ 	return icc_set_bw(core->video_path, total_avg, total_peak);
+ }
+ 
+-- 
+2.43.0
+

--- a/patch sets/media/0017-media-venus-core-Add-SM8350-resource-struct.patch
+++ b/patch sets/media/0017-media-venus-core-Add-SM8350-resource-struct.patch
@@ -1,0 +1,75 @@
+From 8cdfa36d879adc4ed79a4cb6662eaa9dde6f1884 Mon Sep 17 00:00:00 2001
+From: Konrad Dybcio <konrad.dybcio@linaro.org>
+Date: Fri, 4 Aug 2023 22:09:12 +0200
+Subject: [PATCH] media: venus: core: Add SM8350 resource struct
+
+Add SM8350 configuration data and related compatible.
+
+Signed-off-by: Konrad Dybcio <konrad.dybcio@linaro.org>
+Link: https://lore.kernel.org/r/20230731-topic-8280_venus-v1-5-8c8bbe1983a5@linaro.org
+[ johan: rebase on 6.9-rc1; convert vcodec_pmdomains ]
+Signed-off-by: Johan Hovold <johan+linaro@kernel.org>
+---
+ drivers/media/platform/qcom/venus/core.c | 39 ++++++++++++++++++++++++
+ 1 file changed, 39 insertions(+)
+
+diff --git a/drivers/media/platform/qcom/venus/core.c b/drivers/media/platform/qcom/venus/core.c
+index 1f42792f0338..747f13442e93 100644
+--- a/drivers/media/platform/qcom/venus/core.c
++++ b/drivers/media/platform/qcom/venus/core.c
+@@ -1025,6 +1025,44 @@ static const struct venus_resources sm8250_res = {
+ 	.enc_nodename = "video-encoder",
+ };
+ 
++static const struct reg_val sm8350_reg_preset[] = {
++	{ 0xb0088, 0, 0x11 },
++};
++
++static const struct venus_resources sm8350_res = {
++	.freq_tbl = sm8250_freq_table,
++	.freq_tbl_size = ARRAY_SIZE(sm8250_freq_table),
++	.reg_tbl = sm8350_reg_preset,
++	.reg_tbl_size = ARRAY_SIZE(sm8350_reg_preset),
++	.bw_tbl_enc = sm8250_bw_table_enc,
++	.bw_tbl_enc_size = ARRAY_SIZE(sm8250_bw_table_enc),
++	.bw_tbl_dec = sm8250_bw_table_dec,
++	.bw_tbl_dec_size = ARRAY_SIZE(sm8250_bw_table_dec),
++	.clks = { "core", "iface" },
++	.clks_num = 2,
++	.resets = { "core" },
++	.resets_num = 1,
++	.vcodec0_clks = { "vcodec0_core" },
++	.vcodec_clks_num = 1,
++	.vcodec_pmdomains = (const char *[]) { "venus", "vcodec0" },
++	.vcodec_pmdomains_num = 2,
++	.opp_pmdomain = (const char *[]) { "mx", NULL },
++	.vcodec_num = 1,
++	.max_load = 7833600, /* 7680x4320@60fps */
++	.hfi_version = HFI_VERSION_6XX,
++	.vpu_version = VPU_VERSION_IRIS2,
++	.num_vpp_pipes = 4,
++	.vmem_id = VIDC_RESOURCE_NONE,
++	.vmem_size = 0,
++	.vmem_addr = 0,
++	.dma_mask = GENMASK(31, 29) - 1,
++	.cp_start = 0,
++	.cp_size = 0x25800000,
++	.cp_nonpixel_start = 0x1000000,
++	.cp_nonpixel_size = 0x24800000,
++	.fwname = "qcom/vpu-2.0/venus.mbn",
++};
++
+ static const struct freq_tbl sc7280_freq_table[] = {
+ 	{ 0, 460000000 },
+ 	{ 0, 424000000 },
+@@ -1149,6 +1187,7 @@ static const struct of_device_id venus_dt_match[] = {
+ 	{ .compatible = "qcom,sdm845-venus", .data = &sdm845_res },
+ 	{ .compatible = "qcom,sdm845-venus-v2", .data = &sdm845_res_v2 },
+ 	{ .compatible = "qcom,sm8250-venus", .data = &sm8250_res },
++	{ .compatible = "qcom,sm8350-venus", .data = &sm8350_res },
+ 	{}
+ };
+ MODULE_DEVICE_TABLE(of, venus_dt_match);
+-- 
+2.43.0
+

--- a/patch sets/media/0018-media-venus-core-Add-SC8280XP-resource-struct.patch
+++ b/patch sets/media/0018-media-venus-core-Add-SC8280XP-resource-struct.patch
@@ -1,0 +1,81 @@
+From c1c177727b58fbe89b4e0c3844692fc953c5fc75 Mon Sep 17 00:00:00 2001
+From: Konrad Dybcio <konrad.dybcio@linaro.org>
+Date: Fri, 4 Aug 2023 22:09:13 +0200
+Subject: [PATCH] media: venus: core: Add SC8280XP resource struct
+
+Add SC8280XP configuration data and related compatible.
+
+Signed-off-by: Konrad Dybcio <konrad.dybcio@linaro.org>
+Reviewed-by: Bryan O'Donoghue <bryan.odonoghue@linaro.org>
+Link: https://lore.kernel.org/r/20230731-topic-8280_venus-v1-6-8c8bbe1983a5@linaro.org
+[ johan: rebase on 6.9-rc1; convert vcodec_pmdomains ]
+Signed-off-by: Johan Hovold <johan+linaro@kernel.org>
+---
+ drivers/media/platform/qcom/venus/core.c | 44 ++++++++++++++++++++++++
+ 1 file changed, 44 insertions(+)
+
+diff --git a/drivers/media/platform/qcom/venus/core.c b/drivers/media/platform/qcom/venus/core.c
+index 747f13442e93..71872ea8233a 100644
+--- a/drivers/media/platform/qcom/venus/core.c
++++ b/drivers/media/platform/qcom/venus/core.c
+@@ -1127,6 +1127,49 @@ static const struct venus_resources sc7280_res = {
+ 	.enc_nodename = "video-encoder",
+ };
+ 
++static const struct freq_tbl sc8280xp_freq_table[] = {
++	{ 0, 239999999 },
++	{ 0, 338000000 },
++	{ 0, 366000000 },
++	{ 0, 444000000 },
++	{ 0, 533000000 },
++	{ 0, 560000000 },
++};
++
++static const struct venus_resources sc8280xp_res = {
++	.freq_tbl = sc8280xp_freq_table,
++	.freq_tbl_size = ARRAY_SIZE(sc8280xp_freq_table),
++	.reg_tbl = sm8350_reg_preset,
++	.reg_tbl_size = ARRAY_SIZE(sm8350_reg_preset),
++	.bw_tbl_enc = sm8250_bw_table_enc,
++	.bw_tbl_enc_size = ARRAY_SIZE(sm8250_bw_table_enc),
++	.bw_tbl_dec = sm8250_bw_table_dec,
++	.bw_tbl_dec_size = ARRAY_SIZE(sm8250_bw_table_dec),
++	.clks = { "core", "iface" },
++	.clks_num = 2,
++	.resets = { "core" },
++	.resets_num = 1,
++	.vcodec0_clks = { "vcodec0_core" },
++	.vcodec_clks_num = 1,
++	.vcodec_pmdomains = (const char *[]) { "venus", "vcodec0" },
++	.vcodec_pmdomains_num = 2,
++	.opp_pmdomain = (const char *[]) { "mx", NULL },
++	.vcodec_num = 1,
++	.max_load = 7833600, /* 7680x4320@60fps */
++	.hfi_version = HFI_VERSION_6XX,
++	.vpu_version = VPU_VERSION_IRIS2,
++	.num_vpp_pipes = 4,
++	.vmem_id = VIDC_RESOURCE_NONE,
++	.vmem_size = 0,
++	.vmem_addr = 0,
++	.dma_mask = GENMASK(31, 29) - 1,
++	.cp_start = 0,
++	.cp_size = 0x25800000,
++	.cp_nonpixel_start = 0x1000000,
++	.cp_nonpixel_size = 0x24800000,
++	.fwname = "qcom/vpu-2.0/venus.mbn",
++};
++
+ static const struct bw_tbl qcm2290_bw_table_dec[] = {
+ 	{ 352800, 597000, 0, 746000, 0 }, /* 1080p@30 + 720p@30 */
+ 	{ 244800, 413000, 0, 516000, 0 }, /* 1080p@30 */
+@@ -1183,6 +1226,7 @@ static const struct of_device_id venus_dt_match[] = {
+ 	{ .compatible = "qcom,qcm2290-venus", .data = &qcm2290_res },
+ 	{ .compatible = "qcom,sc7180-venus", .data = &sc7180_res },
+ 	{ .compatible = "qcom,sc7280-venus", .data = &sc7280_res },
++	{ .compatible = "qcom,sc8280xp-venus", .data = &sc8280xp_res },
+ 	{ .compatible = "qcom,sdm660-venus", .data = &sdm660_res },
+ 	{ .compatible = "qcom,sdm845-venus", .data = &sdm845_res },
+ 	{ .compatible = "qcom,sdm845-venus-v2", .data = &sdm845_res_v2 },
+-- 
+2.43.0
+

--- a/patch sets/media/0019-arm64-dts-qcom-sc8280xp-Add-Venus.patch
+++ b/patch sets/media/0019-arm64-dts-qcom-sc8280xp-Add-Venus.patch
@@ -1,0 +1,128 @@
+From 767d2110f2247a6e3e7b21565041770e8b2eb914 Mon Sep 17 00:00:00 2001
+From: Konrad Dybcio <konrad.dybcio@linaro.org>
+Date: Tue, 25 Apr 2023 13:55:39 +0000
+Subject: [PATCH] arm64: dts: qcom: sc8280xp: Add Venus
+
+Add the required nodes to enable Venus on sc8280xp.
+
+Signed-off-by: Konrad Dybcio <konrad.dybcio@linaro.org>
+[ johan: use sm8350 videocc defines ]
+Signed-off-by: Johan Hovold <johan+linaro@kernel.org>
+---
+ arch/arm64/boot/dts/qcom/sc8280xp.dtsi | 86 ++++++++++++++++++++++++++
+ 1 file changed, 86 insertions(+)
+
+diff --git a/arch/arm64/boot/dts/qcom/sc8280xp.dtsi b/arch/arm64/boot/dts/qcom/sc8280xp.dtsi
+index d1bb89dbed59..43418398c3a1 100644
+--- a/arch/arm64/boot/dts/qcom/sc8280xp.dtsi
++++ b/arch/arm64/boot/dts/qcom/sc8280xp.dtsi
+@@ -11,6 +11,7 @@
+ #include <dt-bindings/clock/qcom,rpmh.h>
+ #include <dt-bindings/clock/qcom,sc8280xp-camcc.h>
+ #include <dt-bindings/clock/qcom,sc8280xp-lpasscc.h>
++#include <dt-bindings/clock/qcom,sm8350-videocc.h>
+ #include <dt-bindings/dma/qcom-gpi.h>
+ #include <dt-bindings/interconnect/qcom,osm-l3.h>
+ #include <dt-bindings/interconnect/qcom,sc8280xp.h>
+@@ -692,6 +693,11 @@ reserved-region@85b00000 {
+ 			no-map;
+ 		};
+ 
++		pil_video_mem: pil_video_region@86700000 {
++			reg = <0 0x86700000 0 0x500000>;
++			no-map;
++		};
++
+ 		pil_gpu_mem: gpu-mem@8bf00000 {
+ 			reg = <0 0x8bf00000 0 0x2000>;
+ 			no-map;
+@@ -4182,6 +4188,86 @@ usb_1_dwc3_ss: endpoint {
+ 			};
+ 		};
+ 
++		venus: video-codec@aa00000 {
++			compatible = "qcom,sm8350-venus";
++			reg = <0 0x0aa00000 0 0x100000>;
++			interrupts = <GIC_SPI 174 IRQ_TYPE_LEVEL_HIGH>;
++
++			clocks = <&gcc GCC_VIDEO_AXI0_CLK>,
++				 <&videocc VIDEO_CC_MVS0C_CLK>,
++				 <&videocc VIDEO_CC_MVS0_CLK>;
++			clock-names = "iface",
++				      "core",
++				      "vcodec0_core";
++			power-domains = <&videocc MVS0C_GDSC>,
++					<&videocc MVS0_GDSC>,
++					<&rpmhpd SC8280XP_MX>;
++			power-domain-names = "venus",
++					     "vcodec0",
++					     "mx";
++
++			resets = <&gcc GCC_VIDEO_AXI0_CLK_ARES>;
++			reset-names = "core";
++
++			interconnects = <&gem_noc MASTER_APPSS_PROC 0 &config_noc SLAVE_VENUS_CFG 0>,
++					<&mmss_noc MASTER_VIDEO_P0 0 &mc_virt SLAVE_EBI1 0>,
++					<&mmss_noc MASTER_VIDEO_P0 0 &gem_noc SLAVE_LLCC 0>;
++			interconnect-names = "cpu-cfg",
++					     "video-mem",
++					     "video-llcc";
++
++			operating-points-v2 = <&venus_opp_table>;
++			iommus = <&apps_smmu 0x2e00 0x400>;
++			memory-region = <&pil_video_mem>;
++
++			status = "disabled";
++
++			video-decoder {
++				compatible = "venus-decoder";
++			};
++
++			video-encoder {
++				compatible = "venus-encoder";
++			};
++
++			venus_opp_table: opp-table {
++				compatible = "operating-points-v2";
++
++				opp-720000000 {
++					opp-hz = /bits/ 64 <720000000>;
++					required-opps = <&rpmhpd_opp_low_svs>;
++				};
++
++				opp-1014000000 {
++					opp-hz = /bits/ 64 <1014000000>;
++					required-opps = <&rpmhpd_opp_svs>;
++				};
++
++				opp-1098000000 {
++					opp-hz = /bits/ 64 <1098000000>;
++					required-opps = <&rpmhpd_opp_svs_l1>;
++				};
++
++				opp-1332000000 {
++					opp-hz = /bits/ 64 <1332000000>;
++					required-opps = <&rpmhpd_opp_nom>;
++				};
++			};
++		};
++
++		videocc: clock-controller@abf0000 {
++			compatible = "qcom,sc8280xp-videocc";
++			reg = <0 0x0abf0000 0 0x10000>;
++			clocks = <&rpmhcc RPMH_CXO_CLK>,
++				 <&rpmhcc RPMH_CXO_CLK_A>,
++				 <&sleep_clk>;
++			power-domains = <&rpmhpd SC8280XP_MMCX>;
++			required-opps = <&rpmhpd_opp_low_svs>;
++			#clock-cells = <1>;
++			#reset-cells = <1>;
++			#power-domain-cells = <1>;
++		};
++
+ 		cci0: cci@ac4a000 {
+ 			compatible = "qcom,sc8280xp-cci", "qcom,msm8996-cci";
+ 			reg = <0 0x0ac4a000 0 0x1000>;
+-- 
+2.43.0
+

--- a/patch sets/media/0020-arm64-dts-qcom-sc8280xp-huawei-gaokun3-Enable-Venus.patch
+++ b/patch sets/media/0020-arm64-dts-qcom-sc8280xp-huawei-gaokun3-Enable-Venus.patch
@@ -1,0 +1,29 @@
+From a791b5f897571bbc9bcdeeea342617d82005a094 Mon Sep 17 00:00:00 2001
+From: Konrad Dybcio <konrad.dybcio@linaro.org>
+Date: Mon, 30 Mar 2026 23:07:56 +0800
+Subject: [PATCH] arm64: dts: qcom: sc8280xp-huawei-gaokun3: Enable Venus
+
+Enable Venus and point the driver to the correct firmware file.
+---
+ arch/arm64/boot/dts/qcom/sc8280xp-huawei-gaokun3.dts | 5 +++++
+ 1 file changed, 5 insertions(+)
+
+diff --git a/arch/arm64/boot/dts/qcom/sc8280xp-huawei-gaokun3.dts b/arch/arm64/boot/dts/qcom/sc8280xp-huawei-gaokun3.dts
+index f3cd78e81..63efa8918 100644
+--- a/arch/arm64/boot/dts/qcom/sc8280xp-huawei-gaokun3.dts
++++ b/arch/arm64/boot/dts/qcom/sc8280xp-huawei-gaokun3.dts
+@@ -1404,6 +1404,11 @@ &vamacro {
+ 	status = "okay";
+ };
+ 
++&venus {
++	firmware-name = "qcom/sc8280xp/HUAWEI/gaokun3/qcvss8280.mbn";
++	status = "okay";
++};
++
+ &wsamacro {
+ 	status = "okay";
+ };
+-- 
+2.43.0
+


### PR DESCRIPTION
Tested hardware decoding with:
`mpv --hwdec=v4l2m2m-copy --vo=gpu --swapchain-depth=8 --sws-fast=yes video.mp4`

HEVC and AVC playback both worked correctly on gaokun3.
`cat /proc/interrupts | grep venus` showed increasing Venus interrupt counts during playback, confirming that the hardware decoder is active.

These patches were cherry-picked/adapted from:
https://github.com/jhovold/linux/commits/wip/sc8280xp-6.16/