### PR TITLE
patches: add EL2/KVM support patches and document virtualisation

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -71,7 +71,7 @@ Refer to [this](https://github.com/jhovold/linux/wiki/X13s) as well. If you want
 | USB-PD | works | fast charging(45W+) supported with UCSI EC driver |
 | USB-C DisplayPort Alt Mode | works | it may be broken nowadays (untested since ~6.14) |
 | Video acceleration | works | see [below](#Video-acceleration) |
-| Virtualisation | untested | see [here](https://github.com/TravMurav/slbounce) |
+| Virtualisation | works | see [below](#Virtualisation)|
 | Volumn keys | works | |
 | Watchdog | partial | One in sc8280xp works, another in EC not |
 | Wi-Fi | works | see [below](#Wi-Fi) |
@@ -249,6 +249,19 @@ SLPI(Sensor Low Power Island), [more details](https://lore.kernel.org/linux-devi
 ## Video acceleration
 Hardware video acceleration is supported via the Qualcomm Venus engine using the `v4l2m2m` API. Examples of usage:
 - **mpv**: `mpv --hwdec=v4l2m2m-copy <video>`
+
+## Virtualisation
+
+EL2 / KVM works on gaokun with an EL2 boot flow.
+
+Minimal setup:
+- use [`slbounce`](https://github.com/TravMurav/slbounce) to switch into EL2 at `ExitBootServices()`
+- use [`qebspil`](https://github.com/stephan-gh/qebspil) before Linux boot if you want DSP / remoteproc-dependent functions (such as audio) to work in EL2
+- place the required firmware files in the correct EFI path
+- boot Linux with the EL2 device tree (for example `sc8280xp-huawei-gaokun3-el2.dtb`)
+
+Kernel side should have virtualization, remoteproc, and Qualcomm PAS/Q6V5 support enabled.
+`slbounce` gets the system into EL2, while `qebspil` pre-starts the DSPs so Linux can hand them over correctly later.
 
 ## Wi-Fi
 Use [the script](https://github.com/qca/qca-swiss-army-knife/blob/master/tools/scripts/ath11k/ath11k-bdencoder),

--- a/patch sets/el2/0001-soc-qcom-smp2p-Kick-after-requesting-interrupt.patch
+++ b/patch sets/el2/0001-soc-qcom-smp2p-Kick-after-requesting-interrupt.patch
@@ -1,0 +1,46 @@
+From eced965b96efe8a717f77024b7b8906fbf4ba7b7 Mon Sep 17 00:00:00 2001
+From: Stephan Gerhold <stephan.gerhold@linaro.org>
+Date: Fri, 25 Jul 2025 13:07:37 +0200
+Subject: [PATCH 01/24] soc: qcom: smp2p: Kick after requesting interrupt
+
+There is a small chance that an already running remoteproc does not take
+kicking it lightly and kicks us back immediately after. If this happens
+during probe() there is an even smaller chance that we might miss the
+incoming interrupt, because it is not registered yet.
+
+Avoid this race condition by kicking the outgoing edge only after we
+started listening for incoming interrupts.
+
+Fixes: 50e99641413e ("soc: qcom: smp2p: Qualcomm Shared Memory Point to Point")
+Signed-off-by: Stephan Gerhold <stephan.gerhold@linaro.org>
+---
+ drivers/soc/qcom/smp2p.c | 6 +++---
+ 1 file changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/drivers/soc/qcom/smp2p.c b/drivers/soc/qcom/smp2p.c
+index cb515c2340c1..1ea4d35c6d8b 100644
+--- a/drivers/soc/qcom/smp2p.c
++++ b/drivers/soc/qcom/smp2p.c
+@@ -618,9 +618,6 @@ static int qcom_smp2p_probe(struct platform_device *pdev)
+ 		}
+ 	}
+ 
+-	/* Kick the outgoing edge after allocating entries */
+-	qcom_smp2p_kick(smp2p);
+-
+ 	ret = devm_request_threaded_irq(&pdev->dev, irq,
+ 					NULL, qcom_smp2p_intr,
+ 					IRQF_ONESHOT,
+@@ -630,6 +627,9 @@ static int qcom_smp2p_probe(struct platform_device *pdev)
+ 		goto unwind_interfaces;
+ 	}
+ 
++	/* Kick the outgoing edge after allocating entries */
++	qcom_smp2p_kick(smp2p);
++
+ 	/*
+ 	 * Treat smp2p interrupt as wakeup source, but keep it disabled
+ 	 * by default. User space can decide enabling it depending on its
+-- 
+2.43.0
+

--- a/patch sets/el2/0002-soc-qcom-smp2p-Ensure-there-is-enough-space-for-outb.patch
+++ b/patch sets/el2/0002-soc-qcom-smp2p-Ensure-there-is-enough-space-for-outb.patch
@@ -1,0 +1,33 @@
+From c0ff62d5af2cb440e15c88c5bbb74f3670919143 Mon Sep 17 00:00:00 2001
+From: Stephan Gerhold <stephan.gerhold@linaro.org>
+Date: Fri, 25 Jul 2025 11:42:34 +0200
+Subject: [PATCH 02/24] soc: qcom: smp2p: Ensure there is enough space for
+ outbound entries
+
+The SMP2P SMEM item has limited space for outbound entries, but the DT can
+specify any number of entries. Add a check to prevent out of bounds writes
+when an invalid DT specifies more entries than expected.
+
+Fixes: 50e99641413e ("soc: qcom: smp2p: Qualcomm Shared Memory Point to Point")
+Signed-off-by: Stephan Gerhold <stephan.gerhold@linaro.org>
+---
+ drivers/soc/qcom/smp2p.c | 3 +++
+ 1 file changed, 3 insertions(+)
+
+diff --git a/drivers/soc/qcom/smp2p.c b/drivers/soc/qcom/smp2p.c
+index 1ea4d35c6d8b..876648d0b58e 100644
+--- a/drivers/soc/qcom/smp2p.c
++++ b/drivers/soc/qcom/smp2p.c
+@@ -441,6 +441,9 @@ static int qcom_smp2p_outbound_entry(struct qcom_smp2p *smp2p,
+ 	struct smp2p_smem_item *out = smp2p->out;
+ 	char buf[SMP2P_MAX_ENTRY_NAME] = {};
+ 
++	if (out->valid_entries == out->total_entries)
++		return -ENOMEM;
++
+ 	/* Allocate an entry from the smem item */
+ 	strscpy(buf, entry->name, SMP2P_MAX_ENTRY_NAME);
+ 	memcpy(out->entries[out->valid_entries].name, buf, SMP2P_MAX_ENTRY_NAME);
+-- 
+2.43.0
+

--- a/patch sets/el2/0003-soc-qcom-smp2p-Use-length-limited-strncmp-for-compar.patch
+++ b/patch sets/el2/0003-soc-qcom-smp2p-Use-length-limited-strncmp-for-compar.patch
@@ -1,0 +1,32 @@
+From 357f326b9eea3b5cfbce3978c12cc9cc079286a3 Mon Sep 17 00:00:00 2001
+From: Stephan Gerhold <stephan.gerhold@linaro.org>
+Date: Fri, 25 Jul 2025 12:21:04 +0200
+Subject: [PATCH 03/24] soc: qcom: smp2p: Use length limited strncmp() for
+ comparing entry names
+
+A rogue (or broken) remoteproc might not null-terminate its entry names.
+Use strncmp() instead of strcmp() to avoid making out of bounds accesses in
+that situation.
+
+Fixes: 50e99641413e ("soc: qcom: smp2p: Qualcomm Shared Memory Point to Point")
+Signed-off-by: Stephan Gerhold <stephan.gerhold@linaro.org>
+---
+ drivers/soc/qcom/smp2p.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/drivers/soc/qcom/smp2p.c b/drivers/soc/qcom/smp2p.c
+index 876648d0b58e..dcf222b1907d 100644
+--- a/drivers/soc/qcom/smp2p.c
++++ b/drivers/soc/qcom/smp2p.c
+@@ -238,7 +238,7 @@ static void qcom_smp2p_notify_in(struct qcom_smp2p *smp2p)
+ 	for (i = smp2p->valid_entries; i < in->valid_entries; i++) {
+ 		list_for_each_entry(entry, &smp2p->inbound, node) {
+ 			memcpy(buf, in->entries[i].name, sizeof(buf));
+-			if (!strcmp(buf, entry->name)) {
++			if (!strncmp(buf, entry->name, SMP2P_MAX_ENTRY_NAME)) {
+ 				entry->value = &in->entries[i].value;
+ 				break;
+ 			}
+-- 
+2.43.0
+

--- a/patch sets/el2/0004-soc-qcom-smp2p-Drop-redundant-stack-copies-of-entry-.patch
+++ b/patch sets/el2/0004-soc-qcom-smp2p-Drop-redundant-stack-copies-of-entry-.patch
@@ -1,0 +1,66 @@
+From 9d122a69122670afe448f09adb47e428b1a7cf6e Mon Sep 17 00:00:00 2001
+From: Stephan Gerhold <stephan.gerhold@linaro.org>
+Date: Fri, 25 Jul 2025 12:21:04 +0200
+Subject: [PATCH 04/24] soc: qcom: smp2p: Drop redundant stack copies of entry
+ names
+
+For the purposes of this driver, a char is always going to be the same size
+as an u8, so we can access the entry names directly instead of making a
+copy on the stack. Several other Qualcomm-related drivers use char directly
+in such binary structs as well (e.g. qcom_battmgr).
+
+Signed-off-by: Stephan Gerhold <stephan.gerhold@linaro.org>
+---
+ drivers/soc/qcom/smp2p.c | 10 +++-------
+ 1 file changed, 3 insertions(+), 7 deletions(-)
+
+diff --git a/drivers/soc/qcom/smp2p.c b/drivers/soc/qcom/smp2p.c
+index dcf222b1907d..176fce4cf339 100644
+--- a/drivers/soc/qcom/smp2p.c
++++ b/drivers/soc/qcom/smp2p.c
+@@ -73,7 +73,7 @@ struct smp2p_smem_item {
+ 	u32 flags;
+ 
+ 	struct {
+-		u8 name[SMP2P_MAX_ENTRY_NAME];
++		char name[SMP2P_MAX_ENTRY_NAME];
+ 		u32 value;
+ 	} entries[SMP2P_MAX_ENTRY];
+ } __packed;
+@@ -228,7 +228,6 @@ static void qcom_smp2p_notify_in(struct qcom_smp2p *smp2p)
+ 	struct smp2p_entry *entry;
+ 	int irq_pin;
+ 	u32 status;
+-	char buf[SMP2P_MAX_ENTRY_NAME];
+ 	u32 val;
+ 	int i;
+ 
+@@ -237,8 +236,7 @@ static void qcom_smp2p_notify_in(struct qcom_smp2p *smp2p)
+ 	/* Match newly created entries */
+ 	for (i = smp2p->valid_entries; i < in->valid_entries; i++) {
+ 		list_for_each_entry(entry, &smp2p->inbound, node) {
+-			memcpy(buf, in->entries[i].name, sizeof(buf));
+-			if (!strncmp(buf, entry->name, SMP2P_MAX_ENTRY_NAME)) {
++			if (!strncmp(in->entries[i].name, entry->name, SMP2P_MAX_ENTRY_NAME)) {
+ 				entry->value = &in->entries[i].value;
+ 				break;
+ 			}
+@@ -439,14 +437,12 @@ static int qcom_smp2p_outbound_entry(struct qcom_smp2p *smp2p,
+ 				     struct device_node *node)
+ {
+ 	struct smp2p_smem_item *out = smp2p->out;
+-	char buf[SMP2P_MAX_ENTRY_NAME] = {};
+ 
+ 	if (out->valid_entries == out->total_entries)
+ 		return -ENOMEM;
+ 
+ 	/* Allocate an entry from the smem item */
+-	strscpy(buf, entry->name, SMP2P_MAX_ENTRY_NAME);
+-	memcpy(out->entries[out->valid_entries].name, buf, SMP2P_MAX_ENTRY_NAME);
++	strscpy(out->entries[out->valid_entries].name, entry->name, SMP2P_MAX_ENTRY_NAME);
+ 
+ 	/* Make the logical entry reference the physical value */
+ 	entry->value = &out->entries[out->valid_entries].value;
+-- 
+2.43.0
+

--- a/patch sets/el2/0005-soc-qcom-smp2p-Take-over-outgoing-SMEM-items-from-bo.patch
+++ b/patch sets/el2/0005-soc-qcom-smp2p-Take-over-outgoing-SMEM-items-from-bo.patch
@@ -1,0 +1,214 @@
+From 1ce6120c1f9eca9e5d5f2795e8b38ff1b6717d8f Mon Sep 17 00:00:00 2001
+From: Stephan Gerhold <stephan.gerhold@linaro.org>
+Date: Fri, 25 Jul 2025 12:39:16 +0200
+Subject: [PATCH 05/24] soc: qcom: smp2p: Take over outgoing SMEM items from
+ boot firmware
+
+On some platforms (e.g. X1E), the boot firmware already starts some of the
+remoteprocs with a "lite" firmware. This firmware is left running when
+Linux gets started. In this situation, the smp2p driver currently fully
+reinitializes the outgoing SMEM item and ignores the incoming SMEM state
+until the first incoming interrupt. This has worked fine so far, but has
+also has limitations:
+
+ - The initial state of the incoming SMEM item is not captured, so we
+   might miss falling edges reported by the first incoming interrupt.
+
+ - If the SMP2P driver of the remoteproc is implemented similar to the
+   Linux driver, it might cache addresses of the incoming SMP2P entries,
+   but there is no guarantee that we allocate them in the same order as the
+   boot firmware.
+
+ - We may inadvertently send an unexpected SSR ACK, if the boot firmware
+   had the restart ack bit set before.
+
+Implement a more smoother form of handover by reusing the existing outgoing
+SMP2P item if it matches our expectation. Reuse outgoing entries if they
+already exist. Read the initial incoming state and take over the SSR state.
+
+Signed-off-by: Stephan Gerhold <stephan.gerhold@linaro.org>
+---
+ drivers/soc/qcom/smp2p.c | 92 ++++++++++++++++++++++++++++++----------
+ 1 file changed, 69 insertions(+), 23 deletions(-)
+
+diff --git a/drivers/soc/qcom/smp2p.c b/drivers/soc/qcom/smp2p.c
+index 176fce4cf339..775e5c310d27 100644
+--- a/drivers/soc/qcom/smp2p.c
++++ b/drivers/soc/qcom/smp2p.c
+@@ -202,8 +202,6 @@ static void qcom_smp2p_do_ssr_ack(struct qcom_smp2p *smp2p)
+ 	if (smp2p->ssr_ack)
+ 		val |= BIT(SMP2P_FLAGS_RESTART_ACK_BIT);
+ 	out->flags = val;
+-
+-	qcom_smp2p_kick(smp2p);
+ }
+ 
+ static void qcom_smp2p_negotiate(struct qcom_smp2p *smp2p)
+@@ -214,8 +212,10 @@ static void qcom_smp2p_negotiate(struct qcom_smp2p *smp2p)
+ 	if (in->version == out->version) {
+ 		out->features &= in->features;
+ 
+-		if (out->features & SMP2P_FEATURE_SSR_ACK)
++		if (out->features & SMP2P_FEATURE_SSR_ACK) {
+ 			smp2p->ssr_ack_enabled = true;
++			smp2p->ssr_ack = !!(out->flags & BIT(SMP2P_FLAGS_RESTART_ACK_BIT));
++		}
+ 
+ 		smp2p->negotiation_done = true;
+ 		trace_smp2p_negotiate(smp2p->dev, out->features);
+@@ -274,6 +274,24 @@ static void qcom_smp2p_notify_in(struct qcom_smp2p *smp2p)
+ 	}
+ }
+ 
++static bool qcom_smp2p_scan(struct qcom_smp2p *smp2p)
++{
++	bool ack_restart = false;
++
++	if (!smp2p->negotiation_done)
++		qcom_smp2p_negotiate(smp2p);
++
++	if (smp2p->negotiation_done) {
++		ack_restart = qcom_smp2p_check_ssr(smp2p);
++		qcom_smp2p_notify_in(smp2p);
++
++		if (ack_restart)
++			qcom_smp2p_do_ssr_ack(smp2p);
++	}
++
++	return ack_restart;
++}
++
+ /**
+  * qcom_smp2p_intr() - interrupt handler for incoming notifications
+  * @irq:	unused
+@@ -290,7 +308,6 @@ static irqreturn_t qcom_smp2p_intr(int irq, void *data)
+ 	struct qcom_smp2p *smp2p = data;
+ 	unsigned int smem_id = smp2p->smem_items[SMP2P_INBOUND];
+ 	unsigned int pid = smp2p->remote_pid;
+-	bool ack_restart;
+ 	size_t size;
+ 
+ 	in = smp2p->in;
+@@ -307,16 +324,8 @@ static irqreturn_t qcom_smp2p_intr(int irq, void *data)
+ 		smp2p->in = in;
+ 	}
+ 
+-	if (!smp2p->negotiation_done)
+-		qcom_smp2p_negotiate(smp2p);
+-
+-	if (smp2p->negotiation_done) {
+-		ack_restart = qcom_smp2p_check_ssr(smp2p);
+-		qcom_smp2p_notify_in(smp2p);
+-
+-		if (ack_restart)
+-			qcom_smp2p_do_ssr_ack(smp2p);
+-	}
++	if (qcom_smp2p_scan(smp2p))
++		qcom_smp2p_kick(smp2p);
+ 
+ out:
+ 	return IRQ_HANDLED;
+@@ -437,17 +446,24 @@ static int qcom_smp2p_outbound_entry(struct qcom_smp2p *smp2p,
+ 				     struct device_node *node)
+ {
+ 	struct smp2p_smem_item *out = smp2p->out;
++	int i;
+ 
+-	if (out->valid_entries == out->total_entries)
+-		return -ENOMEM;
++	/* Check if we have an entry already (e.g. allocated by boot firmware) */
++	for (i = 0; i < out->valid_entries; i++)
++		if (!strncmp(out->entries[i].name, entry->name, SMP2P_MAX_ENTRY_NAME))
++			break;
+ 
+-	/* Allocate an entry from the smem item */
+-	strscpy(out->entries[out->valid_entries].name, entry->name, SMP2P_MAX_ENTRY_NAME);
++	if (i == out->valid_entries) {
++		/* Allocate an entry from the smem item */
++		if (i == out->total_entries)
++			return -ENOMEM;
+ 
+-	/* Make the logical entry reference the physical value */
+-	entry->value = &out->entries[out->valid_entries].value;
++		strscpy(out->entries[i].name, entry->name, SMP2P_MAX_ENTRY_NAME);
++		out->valid_entries++;
++	}
+ 
+-	out->valid_entries++;
++	/* Make the logical entry reference the physical value */
++	entry->value = &out->entries[i].value;
+ 
+ 	entry->state = qcom_smem_state_register(node, &smp2p_state_ops, entry);
+ 	if (IS_ERR(entry->state)) {
+@@ -476,6 +492,29 @@ static int qcom_smp2p_alloc_outbound_item(struct qcom_smp2p *smp2p)
+ 		return PTR_ERR(out);
+ 	}
+ 
++	smp2p->out = out;
++
++	if (ret == -EEXIST && smp2p->in) {
++		if (out->magic == SMP2P_MAGIC &&
++		    out->version == 1 &&
++		    out->local_pid == smp2p->local_pid &&
++		    out->remote_pid == smp2p->remote_pid &&
++		    out->total_entries >= SMP2P_MAX_ENTRY &&
++		    out->valid_entries <= out->total_entries) {
++			/*
++			 * Reuse existing smem item, but adjust features to
++			 * what we support. This will be updated later when we
++			 * negotiate with the features of the remote side.
++			 */
++			out->features = SMP2P_ALL_FEATURES;
++			return 0;
++		} else {
++			dev_warn(smp2p->dev, "Unexpected local smp2p item allocated by firmware, resetting. "
++				 "(magic: %#x, version: %d, local_pid: %d, remote_pid: %d, total_entries: %d, valid_entries: %d)\n",
++				 out->magic, out->version, out->local_pid, out->remote_pid, out->total_entries, out->valid_entries);
++		}
++	}
++
+ 	memset(out, 0, sizeof(*out));
+ 	out->magic = SMP2P_MAGIC;
+ 	out->local_pid = smp2p->local_pid;
+@@ -493,8 +532,6 @@ static int qcom_smp2p_alloc_outbound_item(struct qcom_smp2p *smp2p)
+ 
+ 	qcom_smp2p_kick(smp2p);
+ 
+-	smp2p->out = out;
+-
+ 	return 0;
+ }
+ 
+@@ -534,6 +571,7 @@ static int smp2p_parse_ipc(struct qcom_smp2p *smp2p)
+ 
+ static int qcom_smp2p_probe(struct platform_device *pdev)
+ {
++	struct smp2p_smem_item *in;
+ 	struct smp2p_entry *entry;
+ 	struct qcom_smp2p *smp2p;
+ 	const char *key;
+@@ -584,6 +622,10 @@ static int qcom_smp2p_probe(struct platform_device *pdev)
+ 			return ret;
+ 	}
+ 
++	in = qcom_smem_get(smp2p->remote_pid, smp2p->smem_items[SMP2P_INBOUND], NULL);
++	if (!IS_ERR(in))
++		smp2p->in = in;
++
+ 	ret = qcom_smp2p_alloc_outbound_item(smp2p);
+ 	if (ret < 0)
+ 		goto release_mbox;
+@@ -617,6 +659,10 @@ static int qcom_smp2p_probe(struct platform_device *pdev)
+ 		}
+ 	}
+ 
++	if (smp2p->in)
++		/* Ignore return status since we kick unconditionally below */
++		qcom_smp2p_scan(smp2p);
++
+ 	ret = devm_request_threaded_irq(&pdev->dev, irq,
+ 					NULL, qcom_smp2p_intr,
+ 					IRQF_ONESHOT,
+-- 
+2.43.0
+

--- a/patch sets/el2/0006-soc-qcom-smp2p-Add-support-for-irq_get_irqchip_state.patch
+++ b/patch sets/el2/0006-soc-qcom-smp2p-Add-support-for-irq_get_irqchip_state.patch
@@ -1,0 +1,56 @@
+From b965bd54a84c410088eb2ac6b626b3cec62ee128 Mon Sep 17 00:00:00 2001
+From: Stephan Gerhold <stephan.gerhold@linaro.org>
+Date: Fri, 25 Jul 2025 13:22:21 +0200
+Subject: [PATCH 06/24] soc: qcom: smp2p: Add support for
+ irq_get_irqchip_state()
+
+Make it possible to read the current SMP2P interrupt state using
+irq_get_irqchip_state(). This can be used for example to check the status
+of the SMP2P interrupts during boot.
+
+Signed-off-by: Stephan Gerhold <stephan.gerhold@linaro.org>
+---
+ drivers/soc/qcom/smp2p.c | 21 +++++++++++++++++++++
+ 1 file changed, 21 insertions(+)
+
+diff --git a/drivers/soc/qcom/smp2p.c b/drivers/soc/qcom/smp2p.c
+index 775e5c310d27..983bf72c5c0d 100644
+--- a/drivers/soc/qcom/smp2p.c
++++ b/drivers/soc/qcom/smp2p.c
+@@ -375,12 +375,33 @@ static void smp2p_irq_print_chip(struct irq_data *irqd, struct seq_file *p)
+ 	seq_printf(p, "%8s", dev_name(entry->smp2p->dev));
+ }
+ 
++static int smp2p_get_irqchip_state(struct irq_data *irqd,
++				   enum irqchip_irq_state which, bool *state)
++{
++	struct smp2p_entry *entry = irq_data_get_irq_chip_data(irqd);
++	irq_hw_number_t irq = irqd_to_hwirq(irqd);
++	u32 val;
++
++	if (which != IRQCHIP_STATE_LINE_LEVEL)
++		return -EINVAL;
++
++	if (entry->value) {
++		val = readl(entry->value);
++		*state = !!(val & BIT(irq));
++	} else {
++		*state = 0;
++	}
++
++	return 0;
++}
++
+ static struct irq_chip smp2p_irq_chip = {
+ 	.name           = "smp2p",
+ 	.irq_mask       = smp2p_mask_irq,
+ 	.irq_unmask     = smp2p_unmask_irq,
+ 	.irq_set_type	= smp2p_set_irq_type,
+ 	.irq_print_chip = smp2p_irq_print_chip,
++	.irq_get_irqchip_state = smp2p_get_irqchip_state,
+ };
+ 
+ static int smp2p_irq_map(struct irq_domain *d,
+-- 
+2.43.0
+

--- a/patch sets/el2/0007-remoteproc-core-Allow-restarting-detached-remoteproc.patch
+++ b/patch sets/el2/0007-remoteproc-core-Allow-restarting-detached-remoteproc.patch
@@ -1,0 +1,371 @@
+From 959e0d344bcbfae6c5fee33e0882872f16571adb Mon Sep 17 00:00:00 2001
+From: Stephan Gerhold <stephan.gerhold@linaro.org>
+Date: Fri, 25 Jul 2025 15:21:40 +0200
+Subject: [PATCH 07/24] remoteproc: core: Allow restarting detached remoteprocs
+ with new firmware
+
+At the moment, the remoteproc core supports only one auto boot "strategy":
+A remoteproc that is already running during boot ("detached") is attached,
+a remoteproc that is offline is started after loading the firmware. This
+works if the firmware loaded during boot is the same that we would start
+later, but it could also be outdated or a reduced size version that is
+missing some functionality. In this case, the best option is to try
+restarting it with new firmware - assuming that it is available while
+booting.
+
+Add support for this alternative behavior by replacing the "auto_boot" bool
+with a more explicit enum rproc_auto_boot.
+
+For RPROC_AUTO_BOOT_RESTART_IF_FW_AVAILABLE, try requesting the firmware
+early and - if successful - perform a clean stop of the remoteproc so that
+it can be restarted with the new firmware afterwards. A remoteproc driver
+making use of this functionality must handle the stop() callback being
+called during the initial detached state.
+
+Signed-off-by: Stephan Gerhold <stephan.gerhold@linaro.org>
+---
+ drivers/remoteproc/imx_dsp_rproc.c      |  2 +-
+ drivers/remoteproc/imx_rproc.c          |  8 +++--
+ drivers/remoteproc/ingenic_rproc.c      |  5 ++-
+ drivers/remoteproc/pru_rproc.c          |  2 +-
+ drivers/remoteproc/qcom_q6v5_adsp.c     |  5 ++-
+ drivers/remoteproc/qcom_q6v5_mss.c      |  2 +-
+ drivers/remoteproc/qcom_q6v5_pas.c      |  5 ++-
+ drivers/remoteproc/rcar_rproc.c         |  2 +-
+ drivers/remoteproc/remoteproc_core.c    | 47 ++++++++++++++++++-------
+ drivers/remoteproc/stm32_rproc.c        |  8 +++--
+ drivers/remoteproc/wkup_m3_rproc.c      |  2 +-
+ drivers/remoteproc/xlnx_r5_remoteproc.c |  2 +-
+ include/linux/remoteproc.h              | 23 +++++++++++-
+ 13 files changed, 86 insertions(+), 27 deletions(-)
+
+diff --git a/drivers/remoteproc/imx_dsp_rproc.c b/drivers/remoteproc/imx_dsp_rproc.c
+index 008741af9f11..d5412ffcf837 100644
+--- a/drivers/remoteproc/imx_dsp_rproc.c
++++ b/drivers/remoteproc/imx_dsp_rproc.c
+@@ -1176,7 +1176,7 @@ static int imx_dsp_rproc_probe(struct platform_device *pdev)
+ 		return dev_err_probe(dev, ret, "failed on imx_dsp_rproc_clk_get\n");
+ 
+ 	init_completion(&priv->pm_comp);
+-	rproc->auto_boot = false;
++	rproc->auto_boot = RPROC_AUTO_BOOT_DISABLED;
+ 	ret = devm_rproc_add(dev, rproc);
+ 	if (ret)
+ 		return dev_err_probe(dev, ret, "rproc_add failed\n");
+diff --git a/drivers/remoteproc/imx_rproc.c b/drivers/remoteproc/imx_rproc.c
+index 8c8ddbf995a4..c70509d12e52 100644
+--- a/drivers/remoteproc/imx_rproc.c
++++ b/drivers/remoteproc/imx_rproc.c
+@@ -1284,8 +1284,12 @@ static int imx_rproc_probe(struct platform_device *pdev)
+ 			return dev_err_probe(dev, PTR_ERR(priv->clk), "Failed to enable clock\n");
+ 	}
+ 
+-	if (rproc->state != RPROC_DETACHED)
+-		rproc->auto_boot = of_property_read_bool(np, "fsl,auto-boot");
++	if (rproc->state != RPROC_DETACHED) {
++		if (of_property_read_bool(np, "fsl,auto-boot"))
++			rproc->auto_boot = RPROC_AUTO_BOOT_ATTACH_OR_START;
++		else
++			rproc->auto_boot = RPROC_AUTO_BOOT_DISABLED;
++	}
+ 
+ 	if (dcfg->flags & IMX_RPROC_NEED_SYSTEM_OFF) {
+ 		/*
+diff --git a/drivers/remoteproc/ingenic_rproc.c b/drivers/remoteproc/ingenic_rproc.c
+index 1b78d8ddeacf..351b95297137 100644
+--- a/drivers/remoteproc/ingenic_rproc.c
++++ b/drivers/remoteproc/ingenic_rproc.c
+@@ -177,7 +177,10 @@ static int ingenic_rproc_probe(struct platform_device *pdev)
+ 	if (!rproc)
+ 		return -ENOMEM;
+ 
+-	rproc->auto_boot = auto_boot;
++	if (auto_boot)
++		rproc->auto_boot = RPROC_AUTO_BOOT_ATTACH_OR_START;
++	else
++		rproc->auto_boot = RPROC_AUTO_BOOT_DISABLED;
+ 
+ 	vpu = rproc->priv;
+ 	vpu->dev = &pdev->dev;
+diff --git a/drivers/remoteproc/pru_rproc.c b/drivers/remoteproc/pru_rproc.c
+index 5e3eb7b86a0e..2ac2d2d5d090 100644
+--- a/drivers/remoteproc/pru_rproc.c
++++ b/drivers/remoteproc/pru_rproc.c
+@@ -1031,7 +1031,7 @@ static int pru_rproc_probe(struct platform_device *pdev)
+ 	 * remote-processor as part of its state machine either through the
+ 	 * remoteproc sysfs interface or through the equivalent kernel API.
+ 	 */
+-	rproc->auto_boot = false;
++	rproc->auto_boot = RPROC_AUTO_BOOT_DISABLED;
+ 
+ 	pru = rproc->priv;
+ 	pru->dev = dev;
+diff --git a/drivers/remoteproc/qcom_q6v5_adsp.c b/drivers/remoteproc/qcom_q6v5_adsp.c
+index b5c8d6d38c9c..7184f73be691 100644
+--- a/drivers/remoteproc/qcom_q6v5_adsp.c
++++ b/drivers/remoteproc/qcom_q6v5_adsp.c
+@@ -673,7 +673,10 @@ static int adsp_probe(struct platform_device *pdev)
+ 		return -ENOMEM;
+ 	}
+ 
+-	rproc->auto_boot = desc->auto_boot;
++	if (desc->auto_boot)
++		rproc->auto_boot = RPROC_AUTO_BOOT_ATTACH_OR_START;
++	else
++		rproc->auto_boot = RPROC_AUTO_BOOT_DISABLED;
+ 	rproc->has_iommu = desc->has_iommu;
+ 	rproc_coredump_set_elf_info(rproc, ELFCLASS32, EM_NONE);
+ 
+diff --git a/drivers/remoteproc/qcom_q6v5_mss.c b/drivers/remoteproc/qcom_q6v5_mss.c
+index 91940977ca89..fcb9604e6bf4 100644
+--- a/drivers/remoteproc/qcom_q6v5_mss.c
++++ b/drivers/remoteproc/qcom_q6v5_mss.c
+@@ -2057,7 +2057,7 @@ static int q6v5_probe(struct platform_device *pdev)
+ 		return -ENOMEM;
+ 	}
+ 
+-	rproc->auto_boot = false;
++	rproc->auto_boot = RPROC_AUTO_BOOT_DISABLED;
+ 	rproc_coredump_set_elf_info(rproc, ELFCLASS32, EM_NONE);
+ 
+ 	qproc = rproc->priv;
+diff --git a/drivers/remoteproc/qcom_q6v5_pas.c b/drivers/remoteproc/qcom_q6v5_pas.c
+index 46204da046fa..c05eed8097ef 100644
+--- a/drivers/remoteproc/qcom_q6v5_pas.c
++++ b/drivers/remoteproc/qcom_q6v5_pas.c
+@@ -774,7 +774,10 @@ static int qcom_pas_probe(struct platform_device *pdev)
+ 	}
+ 
+ 	rproc->has_iommu = of_property_present(pdev->dev.of_node, "iommus");
+-	rproc->auto_boot = desc->auto_boot;
++	if (desc->auto_boot)
++		rproc->auto_boot = RPROC_AUTO_BOOT_ATTACH_OR_START;
++	else
++		rproc->auto_boot = RPROC_AUTO_BOOT_DISABLED;
+ 	rproc_coredump_set_elf_info(rproc, ELFCLASS32, EM_NONE);
+ 
+ 	pas = rproc->priv;
+diff --git a/drivers/remoteproc/rcar_rproc.c b/drivers/remoteproc/rcar_rproc.c
+index 3c25625f966d..99a26a051658 100644
+--- a/drivers/remoteproc/rcar_rproc.c
++++ b/drivers/remoteproc/rcar_rproc.c
+@@ -172,7 +172,7 @@ static int rcar_rproc_probe(struct platform_device *pdev)
+ 	dev_set_drvdata(dev, rproc);
+ 
+ 	/* Manually start the rproc */
+-	rproc->auto_boot = false;
++	rproc->auto_boot = RPROC_AUTO_BOOT_DISABLED;
+ 
+ 	ret = devm_rproc_add(dev, rproc);
+ 	if (ret) {
+diff --git a/drivers/remoteproc/remoteproc_core.c b/drivers/remoteproc/remoteproc_core.c
+index b087ed21858a..ec7565995703 100644
+--- a/drivers/remoteproc/remoteproc_core.c
++++ b/drivers/remoteproc/remoteproc_core.c
+@@ -1683,7 +1683,8 @@ static int rproc_trigger_auto_boot(struct rproc *rproc)
+ 	 * for a firmware image to be loaded, we can simply initiate the process
+ 	 * of attaching to it immediately.
+ 	 */
+-	if (rproc->state == RPROC_DETACHED)
++	if (rproc->state == RPROC_DETACHED &&
++	    rproc->auto_boot != RPROC_AUTO_BOOT_RESTART_IF_FW_AVAILABLE)
+ 		return rproc_boot(rproc);
+ 
+ 	/*
+@@ -1708,8 +1709,9 @@ static int rproc_stop(struct rproc *rproc, bool crashed)
+ 	if (!rproc->ops->stop)
+ 		return -EINVAL;
+ 
+-	/* Stop any subdevices for the remote processor */
+-	rproc_stop_subdevices(rproc, crashed);
++	/* Stop any subdevices for the remote processor if it was attached */
++	if (rproc->state != RPROC_DETACHED)
++		rproc_stop_subdevices(rproc, crashed);
+ 
+ 	/* the installed resource table is no longer accessible */
+ 	ret = rproc_reset_rsc_table_on_stop(rproc);
+@@ -1726,7 +1728,8 @@ static int rproc_stop(struct rproc *rproc, bool crashed)
+ 		return ret;
+ 	}
+ 
+-	rproc_unprepare_subdevices(rproc);
++	if (rproc->state != RPROC_DETACHED)
++		rproc_unprepare_subdevices(rproc);
+ 
+ 	rproc->state = RPROC_OFFLINE;
+ 
+@@ -1903,9 +1906,9 @@ static void rproc_crash_handler_work(struct work_struct *work)
+  */
+ int rproc_boot(struct rproc *rproc)
+ {
+-	const struct firmware *firmware_p;
++	const struct firmware *firmware_p = NULL;
+ 	struct device *dev;
+-	int ret;
++	int ret, fw_ret = 1;
+ 
+ 	if (!rproc) {
+ 		pr_err("invalid rproc handle\n");
+@@ -1932,6 +1935,19 @@ int rproc_boot(struct rproc *rproc)
+ 		goto unlock_mutex;
+ 	}
+ 
++	/* Check early if we have firmware avilable if needed */
++	if (rproc->auto_boot == RPROC_AUTO_BOOT_RESTART_IF_FW_AVAILABLE &&
++	    rproc->state == RPROC_DETACHED) {
++		fw_ret = request_firmware(&firmware_p, rproc->firmware, dev);
++		if (fw_ret == 0) {
++			dev_info(dev, "restarting %s with new firmware\n", rproc->name);
++
++			ret = rproc_stop(rproc, false);
++			if (ret)
++				goto downref_rproc;
++		}
++	}
++
+ 	if (rproc->state == RPROC_DETACHED) {
+ 		dev_info(dev, "attaching to %s\n", rproc->name);
+ 
+@@ -1939,19 +1955,20 @@ int rproc_boot(struct rproc *rproc)
+ 	} else {
+ 		dev_info(dev, "powering up %s\n", rproc->name);
+ 
+-		/* load firmware */
+-		ret = request_firmware(&firmware_p, rproc->firmware, dev);
+-		if (ret < 0) {
+-			dev_err(dev, "request_firmware failed: %d\n", ret);
++		/* load firmware (if not already happened above) */
++		if (fw_ret == 1)
++			fw_ret = request_firmware(&firmware_p, rproc->firmware, dev);
++		if (fw_ret < 0) {
++			dev_err(dev, "request_firmware failed: %d\n", fw_ret);
++			ret = fw_ret;
+ 			goto downref_rproc;
+ 		}
+ 
+ 		ret = rproc_fw_boot(rproc, firmware_p);
+-
+-		release_firmware(firmware_p);
+ 	}
+ 
+ downref_rproc:
++	release_firmware(firmware_p);
+ 	if (ret)
+ 		atomic_dec(&rproc->power);
+ unlock_mutex:
+@@ -2259,6 +2276,10 @@ static int rproc_validate(struct rproc *rproc)
+ 		return -EINVAL;
+ 	}
+ 
++	if (rproc->auto_boot == RPROC_AUTO_BOOT_RESTART_IF_FW_AVAILABLE &&
++	    (!rproc->ops->stop || !rproc->ops->start || !rproc->ops->attach))
++		return -EINVAL;
++
+ 	return 0;
+ }
+ 
+@@ -2470,7 +2491,7 @@ struct rproc *rproc_alloc(struct device *dev, const char *name,
+ 		return NULL;
+ 
+ 	rproc->priv = &rproc[1];
+-	rproc->auto_boot = true;
++	rproc->auto_boot = RPROC_AUTO_BOOT_ATTACH_OR_START;
+ 	rproc->elf_class = ELFCLASSNONE;
+ 	rproc->elf_machine = EM_NONE;
+ 
+diff --git a/drivers/remoteproc/stm32_rproc.c b/drivers/remoteproc/stm32_rproc.c
+index 632614013dc6..891fc17f8a63 100644
+--- a/drivers/remoteproc/stm32_rproc.c
++++ b/drivers/remoteproc/stm32_rproc.c
+@@ -696,7 +696,8 @@ static int stm32_rproc_get_syscon(struct device_node *np, const char *prop,
+ }
+ 
+ static int stm32_rproc_parse_dt(struct platform_device *pdev,
+-				struct stm32_rproc *ddata, bool *auto_boot)
++				struct stm32_rproc *ddata,
++				enum rproc_auto_boot *auto_boot)
+ {
+ 	struct device *dev = &pdev->dev;
+ 	struct device_node *np = dev->of_node;
+@@ -777,7 +778,10 @@ static int stm32_rproc_parse_dt(struct platform_device *pdev,
+ 	if (err)
+ 		dev_info(dev, "failed to get pdds\n");
+ 
+-	*auto_boot = of_property_read_bool(np, "st,auto-boot");
++	if (of_property_read_bool(np, "st,auto-boot"))
++		*auto_boot = RPROC_AUTO_BOOT_ATTACH_OR_START;
++	else
++		*auto_boot = RPROC_AUTO_BOOT_DISABLED;
+ 
+ 	/*
+ 	 * See if we can check the M4 status, i.e if it was started
+diff --git a/drivers/remoteproc/wkup_m3_rproc.c b/drivers/remoteproc/wkup_m3_rproc.c
+index 2d5bfbefcacc..8815648295c8 100644
+--- a/drivers/remoteproc/wkup_m3_rproc.c
++++ b/drivers/remoteproc/wkup_m3_rproc.c
+@@ -170,7 +170,7 @@ static int wkup_m3_rproc_probe(struct platform_device *pdev)
+ 	if (!rproc)
+ 		return -ENOMEM;
+ 
+-	rproc->auto_boot = false;
++	rproc->auto_boot = RPROC_AUTO_BOOT_DISABLED;
+ 	rproc->sysfs_read_only = true;
+ 
+ 	wkupm3 = rproc->priv;
+diff --git a/drivers/remoteproc/xlnx_r5_remoteproc.c b/drivers/remoteproc/xlnx_r5_remoteproc.c
+index b71ce69afe9f..670b7ff4860a 100644
+--- a/drivers/remoteproc/xlnx_r5_remoteproc.c
++++ b/drivers/remoteproc/xlnx_r5_remoteproc.c
+@@ -925,7 +925,7 @@ static struct zynqmp_r5_core *zynqmp_r5_add_rproc_core(struct device *cdev)
+ 
+ 	r5_rproc->recovery_disabled = true;
+ 	r5_rproc->has_iommu = false;
+-	r5_rproc->auto_boot = false;
++	r5_rproc->auto_boot = RPROC_AUTO_BOOT_DISABLED;
+ 	r5_core = r5_rproc->priv;
+ 	r5_core->dev = cdev;
+ 	r5_core->np = dev_of_node(cdev);
+diff --git a/include/linux/remoteproc.h b/include/linux/remoteproc.h
+index b4795698d8c2..c40b18d120ab 100644
+--- a/include/linux/remoteproc.h
++++ b/include/linux/remoteproc.h
+@@ -503,6 +503,27 @@ enum rproc_features {
+ 	RPROC_MAX_FEATURES,
+ };
+ 
++/**
++ * enum rproc_auto_boot - auto boot strategy for remoteproc during initial boot
++ *
++ * @RPROC_AUTO_BOOT_DISABLED: The remoteproc will be left offline (or detached).
++ * @RPROC_AUTO_BOOT_ATTACH_OR_START: The remoteproc will be attached (if it is
++ *				     already running). Otherwise, it will be
++ *				     started with new loaded firmware.
++ * @RPROC_FEAT_REBOOT_IF_FW_AVAILABLE: The remoteproc will be restarted if
++ *				       requesting new firmware succeeds. If
++ *				       the firmware is missing and the
++ *				       remoteproc is already running, it will
++ *				       be attached instead. A remoteproc
++ *				       implementing this must handle stop()
++ *				       being called in detached state.
++ */
++enum rproc_auto_boot {
++	RPROC_AUTO_BOOT_DISABLED,
++	RPROC_AUTO_BOOT_ATTACH_OR_START,
++	RPROC_AUTO_BOOT_RESTART_IF_FW_AVAILABLE,
++};
++
+ /**
+  * struct rproc - represents a physical remote processor device
+  * @node: list node of this rproc object
+@@ -577,7 +598,7 @@ struct rproc {
+ 	struct resource_table *cached_table;
+ 	size_t table_sz;
+ 	bool has_iommu;
+-	bool auto_boot;
++	enum rproc_auto_boot auto_boot;
+ 	bool sysfs_read_only;
+ 	struct list_head dump_segments;
+ 	int nb_vdev;
+-- 
+2.43.0
+

--- a/patch sets/el2/0008-remoteproc-qcom_q6v5-Allow-detecting-detached-state-.patch
+++ b/patch sets/el2/0008-remoteproc-qcom_q6v5-Allow-detecting-detached-state-.patch
@@ -1,0 +1,84 @@
+From 1b44b3a05be31efecd2b39f1609f7732147cdb8a Mon Sep 17 00:00:00 2001
+From: Stephan Gerhold <stephan.gerhold@linaro.org>
+Date: Tue, 5 Aug 2025 17:44:32 +0200
+Subject: [PATCH 08/24] remoteproc: qcom_q6v5: Allow detecting detached state
+ during boot
+
+A remoteproc might be already running during boot, e.g. because it was
+already started by the boot firmware. This should be reflected in the
+initial remoteproc state if the remoteproc driver implements the attach()
+callback.
+
+Add a function that allows checking the initial state of the of the
+remoteproc during boot by reading the state of the SMP2P interrupts. If it
+is running, handover already happened, it was not stopped and did not
+crash, then it is likely in a state where we can attach to it and continue
+using its services.
+
+Note that there is a small chance for false-positives when the remoteproc
+was not shutdown cleanly using the SMP2P signals. There is no firmware that
+does that at the moment. If there is in the future, it should provide a
+more reliable way to check if a remoteproc is already running during boot.
+
+Signed-off-by: Stephan Gerhold <stephan.gerhold@linaro.org>
+---
+ drivers/remoteproc/qcom_q6v5.c | 29 +++++++++++++++++++++++++++++
+ drivers/remoteproc/qcom_q6v5.h |  2 ++
+ 2 files changed, 31 insertions(+)
+
+diff --git a/drivers/remoteproc/qcom_q6v5.c b/drivers/remoteproc/qcom_q6v5.c
+index 58d5b85e58cd..d4d978cca4ba 100644
+--- a/drivers/remoteproc/qcom_q6v5.c
++++ b/drivers/remoteproc/qcom_q6v5.c
+@@ -234,6 +234,35 @@ unsigned long qcom_q6v5_panic(struct qcom_q6v5 *q6v5)
+ }
+ EXPORT_SYMBOL_GPL(qcom_q6v5_panic);
+ 
++/**
++ * qcom_q6v5_read_smp2p_state() - check the initial state during boot using SMP2P
++ * @q6v5:	reference to qcom_q6v5 context
++ *
++ * Read the current state of the SMP2P interrupts and attempt to determine if
++ * the remoteproc is already running. If yes, the remoteproc state is set to
++ * RPROC_DETACHED. Drivers can use this to add support for attaching to
++ * remoteprocs during boot.
++ *
++ * There is a small chance for false-positives, so drivers should combine this
++ * with device-specific status information if possible.
++ */
++void qcom_q6v5_read_smp2p_state(struct qcom_q6v5 *q6v5)
++{
++	bool handover = false;
++	bool ready = false;
++	bool fatal = false;
++	bool stop = false;
++
++	irq_get_irqchip_state(q6v5->handover_irq, IRQCHIP_STATE_LINE_LEVEL, &handover);
++	irq_get_irqchip_state(q6v5->ready_irq, IRQCHIP_STATE_LINE_LEVEL, &ready);
++	irq_get_irqchip_state(q6v5->fatal_irq, IRQCHIP_STATE_LINE_LEVEL, &fatal);
++	irq_get_irqchip_state(q6v5->stop_irq, IRQCHIP_STATE_LINE_LEVEL, &stop);
++
++	if (ready && handover && !stop && !fatal)
++		q6v5->rproc->state = RPROC_DETACHED;
++}
++EXPORT_SYMBOL_GPL(qcom_q6v5_read_smp2p_state);
++
+ /**
+  * qcom_q6v5_init() - initializer of the q6v5 common struct
+  * @q6v5:	handle to be initialized
+diff --git a/drivers/remoteproc/qcom_q6v5.h b/drivers/remoteproc/qcom_q6v5.h
+index 5a859c41896e..59970adb04b1 100644
+--- a/drivers/remoteproc/qcom_q6v5.h
++++ b/drivers/remoteproc/qcom_q6v5.h
+@@ -47,6 +47,8 @@ int qcom_q6v5_init(struct qcom_q6v5 *q6v5, struct platform_device *pdev,
+ 		   void (*handover)(struct qcom_q6v5 *q6v5));
+ void qcom_q6v5_deinit(struct qcom_q6v5 *q6v5);
+ 
++void qcom_q6v5_read_smp2p_state(struct qcom_q6v5 *q6v5);
++
+ int qcom_q6v5_prepare(struct qcom_q6v5 *q6v5);
+ int qcom_q6v5_unprepare(struct qcom_q6v5 *q6v5);
+ int qcom_q6v5_request_stop(struct qcom_q6v5 *q6v5, struct qcom_sysmon *sysmon);
+-- 
+2.43.0
+

--- a/patch sets/el2/0009-remoteproc-qcom_q6v5-Add-qcom_q6v5_attach.patch
+++ b/patch sets/el2/0009-remoteproc-qcom_q6v5-Add-qcom_q6v5_attach.patch
@@ -1,0 +1,103 @@
+From 16295fac26e948dc4e9b0156e7c5d5c3e8b460e9 Mon Sep 17 00:00:00 2001
+From: Stephan Gerhold <stephan.gerhold@linaro.org>
+Date: Tue, 5 Aug 2025 17:44:32 +0200
+Subject: [PATCH 09/24] remoteproc: qcom_q6v5: Add qcom_q6v5_attach()
+
+Implement qcom_q6v5_attach(), which can be used by q6v5 remoteproc drivers
+to attach to a remoteproc that is already running during boot. It is
+essentially the same as qcom_q6v5_prepare(), except that we skip setting up
+the proxy votes, since we expect that handover has already happened.
+
+Signed-off-by: Stephan Gerhold <stephan.gerhold@linaro.org>
+---
+ drivers/remoteproc/qcom_q6v5.c | 44 ++++++++++++++++++++++++++++------
+ drivers/remoteproc/qcom_q6v5.h |  1 +
+ 2 files changed, 38 insertions(+), 7 deletions(-)
+
+diff --git a/drivers/remoteproc/qcom_q6v5.c b/drivers/remoteproc/qcom_q6v5.c
+index d4d978cca4ba..94c75d9cca55 100644
+--- a/drivers/remoteproc/qcom_q6v5.c
++++ b/drivers/remoteproc/qcom_q6v5.c
+@@ -36,6 +36,25 @@ static int q6v5_load_state_toggle(struct qcom_q6v5 *q6v5, bool enable)
+ 	return ret;
+ }
+ 
++static int q6v5_init(struct qcom_q6v5 *q6v5, bool handover_issued)
++{
++	int ret;
++
++	/* Always send correct load state in case it was not done before */
++	ret = q6v5_load_state_toggle(q6v5, true);
++	if (ret)
++		return ret;
++
++	reinit_completion(&q6v5->start_done);
++	reinit_completion(&q6v5->stop_done);
++
++	q6v5->running = true;
++	q6v5->handover_issued = handover_issued;
++
++	enable_irq(q6v5->handover_irq);
++	return 0;
++}
++
+ /**
+  * qcom_q6v5_prepare() - reinitialize the qcom_q6v5 context before start
+  * @q6v5:	reference to qcom_q6v5 context to be reinitialized
+@@ -52,23 +71,34 @@ int qcom_q6v5_prepare(struct qcom_q6v5 *q6v5)
+ 		return ret;
+ 	}
+ 
+-	ret = q6v5_load_state_toggle(q6v5, true);
++	ret = q6v5_init(q6v5, false);
+ 	if (ret) {
+ 		icc_set_bw(q6v5->path, 0, 0);
+ 		return ret;
+ 	}
+ 
+-	reinit_completion(&q6v5->start_done);
+-	reinit_completion(&q6v5->stop_done);
++	return 0;
++}
++EXPORT_SYMBOL_GPL(qcom_q6v5_prepare);
+ 
+-	q6v5->running = true;
+-	q6v5->handover_issued = false;
++/**
++ * qcom_q6v5_attach() - attach to already running qcom_q6v5 remoteproc
++ * @q6v5:	reference to qcom_q6v5 context to be attached
++ *
++ * Return: 0 on success, negative errno on failure
++ */
++int qcom_q6v5_attach(struct qcom_q6v5 *q6v5)
++{
++	int ret;
+ 
+-	enable_irq(q6v5->handover_irq);
++	ret = q6v5_init(q6v5, true);
++	if (ret)
++		return ret;
+ 
++	complete(&q6v5->start_done);
+ 	return 0;
+ }
+-EXPORT_SYMBOL_GPL(qcom_q6v5_prepare);
++EXPORT_SYMBOL_GPL(qcom_q6v5_attach);
+ 
+ /**
+  * qcom_q6v5_unprepare() - unprepare the qcom_q6v5 context after stop
+diff --git a/drivers/remoteproc/qcom_q6v5.h b/drivers/remoteproc/qcom_q6v5.h
+index 59970adb04b1..f034bb628605 100644
+--- a/drivers/remoteproc/qcom_q6v5.h
++++ b/drivers/remoteproc/qcom_q6v5.h
+@@ -50,6 +50,7 @@ void qcom_q6v5_deinit(struct qcom_q6v5 *q6v5);
+ void qcom_q6v5_read_smp2p_state(struct qcom_q6v5 *q6v5);
+ 
+ int qcom_q6v5_prepare(struct qcom_q6v5 *q6v5);
++int qcom_q6v5_attach(struct qcom_q6v5 *q6v5);
+ int qcom_q6v5_unprepare(struct qcom_q6v5 *q6v5);
+ int qcom_q6v5_request_stop(struct qcom_q6v5 *q6v5, struct qcom_sysmon *sysmon);
+ int qcom_q6v5_wait_for_start(struct qcom_q6v5 *q6v5, int timeout);
+-- 
+2.43.0
+

--- a/patch sets/el2/0010-remoteproc-qcom_q6v5-Send-SMP2P-stop-signal-in-attac.patch
+++ b/patch sets/el2/0010-remoteproc-qcom_q6v5-Send-SMP2P-stop-signal-in-attac.patch
@@ -1,0 +1,39 @@
+From b7ef6686896212fbc1edb00e66b210309aee9667 Mon Sep 17 00:00:00 2001
+From: Stephan Gerhold <stephan.gerhold@linaro.org>
+Date: Tue, 5 Aug 2025 17:44:32 +0200
+Subject: [PATCH 10/24] remoteproc: qcom_q6v5: Send SMP2P stop signal in
+ attached/detached state
+
+If we stop the q6v5 remoteproc while it is in RPROC_ATTACHED or
+RPROC_DETACHED state, we still want to send the stop signal to shut it down
+cleanly.
+
+The main goal of the check in qcom_q6v5_request_stop() is to avoid sending
+duplicate shutdown/stop signals during crash or shutdown via sysmon, so
+check for RPROC_CRASHED to handle all of RPROC_RUNNING, RPROC_ATTACHED and
+RPROC_DETACHED. It does not make sense to call the function while in
+RPROC_OFFLINE state.
+
+Signed-off-by: Stephan Gerhold <stephan.gerhold@linaro.org>
+---
+ drivers/remoteproc/qcom_q6v5.c | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/drivers/remoteproc/qcom_q6v5.c b/drivers/remoteproc/qcom_q6v5.c
+index 94c75d9cca55..ed1b578a831d 100644
+--- a/drivers/remoteproc/qcom_q6v5.c
++++ b/drivers/remoteproc/qcom_q6v5.c
+@@ -231,8 +231,8 @@ int qcom_q6v5_request_stop(struct qcom_q6v5 *q6v5, struct qcom_sysmon *sysmon)
+ 
+ 	q6v5->running = false;
+ 
+-	/* Don't perform SMP2P dance if remote isn't running */
+-	if (q6v5->rproc->state != RPROC_RUNNING || qcom_sysmon_shutdown_acked(sysmon))
++	/* Don't perform SMP2P dance if remote crashed or already stopped */
++	if (q6v5->rproc->state == RPROC_CRASHED || qcom_sysmon_shutdown_acked(sysmon))
+ 		return 0;
+ 
+ 	qcom_smem_state_update_bits(q6v5->state,
+-- 
+2.43.0
+

--- a/patch sets/el2/0011-remoteproc-qcom_q6v5_pas-Attach-running-remoteproc-i.patch
+++ b/patch sets/el2/0011-remoteproc-qcom_q6v5_pas-Attach-running-remoteproc-i.patch
@@ -1,0 +1,175 @@
+From 729253961bf5e787e8475067fbe25282eb972bf1 Mon Sep 17 00:00:00 2001
+From: Stephan Gerhold <stephan.gerhold@linaro.org>
+Date: Tue, 5 Aug 2025 17:44:32 +0200
+Subject: [PATCH 11/24] remoteproc: qcom_q6v5_pas: Attach running remoteproc if
+ firmware is missing
+
+A remoteproc might be already running during boot, e.g. because it was
+already started by the boot firmware. This is the case for example on X1E,
+where the boot firmware starts a "lite" ADSP firmware that supports
+charging and USB-CC detection, but is missing audio functionality. This
+firmware uses the same interfaces as the full firmware and can be reused in
+case the device-specific firmware is missing (e.g. in generic distro
+installers).
+
+The running remoteproc is currently not modelled at all - it is just killed
+through qcom_scm_pas_shutdown() without even using the SMP2P stop signal
+beforehand.
+
+Model this properly by marking the remoteproc as RPROC_DETACHED based on
+the SMP2P state and use the new RPROC_AUTO_BOOT_RESTART_IF_FW_AVAILABLE
+feature to implement equivalent behavior as before. If the firmware is
+present the "lite" firmware is now stopped more gracefully with the SMP2P
+stop signal. If the firmware is missing, we attach to it and can provide
+battery status and USB-C detection until the full ADSP firmware is copied.
+
+Note that the exact same approach does not just work for the "lite" ADSP
+firmware. Any of the remoteprocs (ADSP, CDSP, SLPI, ...) can be already
+started during boot and attached (or restarted) later.
+
+Signed-off-by: Stephan Gerhold <stephan.gerhold@linaro.org>
+---
+ drivers/remoteproc/qcom_q6v5_pas.c | 64 +++++++++++++++++++++++++-----
+ 1 file changed, 54 insertions(+), 10 deletions(-)
+
+diff --git a/drivers/remoteproc/qcom_q6v5_pas.c b/drivers/remoteproc/qcom_q6v5_pas.c
+index c05eed8097ef..a84745add654 100644
+--- a/drivers/remoteproc/qcom_q6v5_pas.c
++++ b/drivers/remoteproc/qcom_q6v5_pas.c
+@@ -227,10 +227,13 @@ static int qcom_pas_load(struct rproc *rproc, const struct firmware *fw)
+ 	/* Store firmware handle to be used in qcom_pas_start() */
+ 	pas->firmware = fw;
+ 
+-	if (pas->lite_pas_id)
+-		qcom_scm_pas_shutdown(pas->lite_pas_id);
+-	if (pas->lite_dtb_pas_id)
+-		qcom_scm_pas_shutdown(pas->lite_dtb_pas_id);
++	/*
++	 * We don't support loading the "lite" firmware, so we don't need to
++	 * keep trying to shut it down. If it was running, it should have
++	 * already been stopped by adsp_stop().
++	 */
++	pas->lite_pas_id = 0;
++	pas->lite_dtb_pas_id = 0;
+ 
+ 	if (pas->dtb_pas_id) {
+ 		ret = request_firmware(&pas->dtb_firmware, pas->dtb_firmware_name, pas->dev);
+@@ -396,6 +399,28 @@ static void qcom_pas_handover(struct qcom_q6v5 *q6v5)
+ 	qcom_pas_pds_disable(pas, pas->proxy_pds, pas->proxy_pd_count);
+ }
+ 
++static int qcom_pas_shutdown(int pas_id, int lite_pas_id)
++{
++	int ret, lite_ret = -ENODEV;
++
++	/*
++	 * We don't know if the boot firmware started the "full" or "lite"
++	 * firmware, so we don't know if we need to shutdown the lite_pas_id or
++	 * the normal pas_id. Unfortunately, the return codes of the SCM calls
++	 * are also not helpful to figure that out. Since shutting down a
++	 * stopped remoteproc is a no-op, we just shutdown both and if one of
++	 * the calls succeeds, we assume it's okay.
++	 */
++	if (lite_pas_id)
++		lite_ret = qcom_scm_pas_shutdown(lite_pas_id);
++
++	ret = qcom_scm_pas_shutdown(pas_id);
++	if (ret && lite_ret)
++		return ret;
++
++	return 0;
++}
++
+ static int qcom_pas_stop(struct rproc *rproc)
+ {
+ 	struct qcom_pas *pas = rproc->priv;
+@@ -406,7 +431,7 @@ static int qcom_pas_stop(struct rproc *rproc)
+ 	if (ret == -ETIMEDOUT)
+ 		dev_err(pas->dev, "timed out on wait\n");
+ 
+-	ret = qcom_scm_pas_shutdown(pas->pas_id);
++	ret = qcom_pas_shutdown(pas->pas_id, pas->lite_pas_id);
+ 	if (ret && pas->decrypt_shutdown)
+ 		ret = qcom_pas_shutdown_poll_decrypt(pas);
+ 
+@@ -414,7 +439,7 @@ static int qcom_pas_stop(struct rproc *rproc)
+ 		dev_err(pas->dev, "failed to shutdown: %d\n", ret);
+ 
+ 	if (pas->dtb_pas_id) {
+-		ret = qcom_scm_pas_shutdown(pas->dtb_pas_id);
++		ret = qcom_pas_shutdown(pas->dtb_pas_id, pas->lite_dtb_pas_id);
+ 		if (ret)
+ 			dev_err(pas->dev, "failed to shutdown dtb: %d\n", ret);
+ 
+@@ -423,9 +448,11 @@ static int qcom_pas_stop(struct rproc *rproc)
+ 
+ 	qcom_pas_unmap_carveout(rproc, pas->mem_phys, pas->mem_size);
+ 
+-	handover = qcom_q6v5_unprepare(&pas->q6v5);
+-	if (handover)
+-		qcom_pas_handover(&pas->q6v5);
++	if (rproc->state != RPROC_DETACHED) {
++		handover = qcom_q6v5_unprepare(&pas->q6v5);
++		if (handover)
++			qcom_pas_handover(&pas->q6v5);
++	}
+ 
+ 	if (pas->smem_host_id)
+ 		ret = qcom_smem_bust_hwspin_lock_by_host(pas->smem_host_id);
+@@ -433,6 +460,13 @@ static int qcom_pas_stop(struct rproc *rproc)
+ 	return ret;
+ }
+ 
++static int qcom_pas_attach(struct rproc *rproc)
++{
++	struct qcom_pas *pas = rproc->priv;
++
++	return qcom_q6v5_attach(&pas->q6v5);
++}
++
+ static void *qcom_pas_da_to_va(struct rproc *rproc, u64 da, size_t len, bool *is_iomem)
+ {
+ 	struct qcom_pas *pas = rproc->priv;
+@@ -514,6 +548,7 @@ static const struct rproc_ops qcom_pas_ops = {
+ 	.unprepare = qcom_pas_unprepare,
+ 	.start = qcom_pas_start,
+ 	.stop = qcom_pas_stop,
++	.attach = qcom_pas_attach,
+ 	.da_to_va = qcom_pas_da_to_va,
+ 	.parse_fw = qcom_pas_parse_firmware,
+ 	.load = qcom_pas_load,
+@@ -524,6 +559,7 @@ static const struct rproc_ops qcom_pas_minidump_ops = {
+ 	.unprepare = qcom_pas_unprepare,
+ 	.start = qcom_pas_start,
+ 	.stop = qcom_pas_stop,
++	.attach = qcom_pas_attach,
+ 	.da_to_va = qcom_pas_da_to_va,
+ 	.parse_fw = qcom_pas_parse_firmware,
+ 	.load = qcom_pas_load,
+@@ -775,7 +811,7 @@ static int qcom_pas_probe(struct platform_device *pdev)
+ 
+ 	rproc->has_iommu = of_property_present(pdev->dev.of_node, "iommus");
+ 	if (desc->auto_boot)
+-		rproc->auto_boot = RPROC_AUTO_BOOT_ATTACH_OR_START;
++		rproc->auto_boot = RPROC_AUTO_BOOT_RESTART_IF_FW_AVAILABLE;
+ 	else
+ 		rproc->auto_boot = RPROC_AUTO_BOOT_DISABLED;
+ 	rproc_coredump_set_elf_info(rproc, ELFCLASS32, EM_NONE);
+@@ -830,6 +866,14 @@ static int qcom_pas_probe(struct platform_device *pdev)
+ 	if (ret)
+ 		goto detach_proxy_pds;
+ 
++	/*
++	 * Unfortunately, the PAS interface does not provide a reliable way to
++	 * check if a certain pas_id is currently running. Reading the smp2p
++	 * state is the best we can do to check if the remoteproc is already
++	 * running during boot.
++	 */
++	qcom_q6v5_read_smp2p_state(&pas->q6v5);
++
+ 	qcom_add_glink_subdev(rproc, &pas->glink_subdev, desc->ssr_name);
+ 	qcom_add_smd_subdev(rproc, &pas->smd_subdev);
+ 	qcom_add_pdm_subdev(rproc, &pas->pdm_subdev);
+-- 
+2.43.0
+

--- a/patch sets/el2/0012-dt-bindings-firmware-qcom-scm-Add-qcom-shm-bridge-vm.patch
+++ b/patch sets/el2/0012-dt-bindings-firmware-qcom-scm-Add-qcom-shm-bridge-vm.patch
@@ -1,0 +1,46 @@
+From 4e73c5c01f827af0dc25d407da91d4d6338b6eca Mon Sep 17 00:00:00 2001
+From: Stephan Gerhold <stephan@gerhold.net>
+Date: Sun, 26 Oct 2025 14:50:30 +0100
+Subject: [PATCH 12/24] dt-bindings: firmware: qcom,scm: Add
+ qcom,shm-bridge-vmid
+
+Signed-off-by: Stephan Gerhold <stephan@gerhold.net>
+---
+ Documentation/devicetree/bindings/firmware/qcom,scm.yaml | 8 ++++++++
+ include/dt-bindings/firmware/qcom,scm.h                  | 3 +++
+ 2 files changed, 11 insertions(+)
+
+diff --git a/Documentation/devicetree/bindings/firmware/qcom,scm.yaml b/Documentation/devicetree/bindings/firmware/qcom,scm.yaml
+index d66459f1d84e..bf75cc9a375b 100644
+--- a/Documentation/devicetree/bindings/firmware/qcom,scm.yaml
++++ b/Documentation/devicetree/bindings/firmware/qcom,scm.yaml
+@@ -108,6 +108,14 @@ properties:
+       Phandle to the memory region reserved for the shared memory bridge to TZ.
+     maxItems: 1
+ 
++  qcom,shm-bridge-vmid:
++    $ref: /schemas/types.yaml#/definitions/uint32
++    description:
++      VMID to use as owner of shared memory bridge allocations for TZ.
++      QCOM_SCM_VMID_SELF_OWNER may be used to indicate that the allocations
++      should be self-owned rather than being assigned to a specific VMID.
++      Defaults to QCOM_SCM_VMID_HLOS if not specified.
++
+   qcom,sdi-enabled:
+     description:
+       Indicates that the SDI (Secure Debug Image) has been enabled by TZ
+diff --git a/include/dt-bindings/firmware/qcom,scm.h b/include/dt-bindings/firmware/qcom,scm.h
+index 6de8b08e1e79..1e0a477f0db9 100644
+--- a/include/dt-bindings/firmware/qcom,scm.h
++++ b/include/dt-bindings/firmware/qcom,scm.h
+@@ -36,4 +36,7 @@
+ #define QCOM_SCM_VMID_TVM		0x2D
+ #define QCOM_SCM_VMID_OEMVM		0x31
+ 
++/* Special value intended for qcom,shm-bridge-vmid */
++#define QCOM_SCM_VMID_SELF_OWNER	0xffffffff
++
+ #endif
+-- 
+2.43.0
+

--- a/patch sets/el2/0013-wip-firmware-qcom-tzmem-Use-self-owner-bits-when-run.patch
+++ b/patch sets/el2/0013-wip-firmware-qcom-tzmem-Use-self-owner-bits-when-run.patch
@@ -1,0 +1,89 @@
+From bd3feba340970b22ca517196dfb971f663e42214 Mon Sep 17 00:00:00 2001
+From: Stephan Gerhold <stephan.gerhold@linaro.org>
+Date: Sun, 20 Jul 2025 16:15:54 +0200
+Subject: [PATCH 13/24] wip: firmware: qcom: tzmem: Use "self owner" bits when
+ running in EL2
+
+It seems like the SHM bridge needs to use a different set of bits (the
+"self owner" bits) when running as the hypervisor in EL2.
+
+Make the SHM bridge (and SCM calls in general) work properly in EL2 by
+porting a similar change from the msm-5.4 vendor kernel:
+git.codelinaro.org/clo/la/kernel/msm-5.4/-/commit/9cb1271ce620ab7cdd53f00c9d951004c9713254
+
+TODO: This should be likely changed to a DT property, since usage of
+is_hyp_mode_available() is discouraged in drivers.
+
+Add qcom,shm-bridge-vmid property instead of checking explicitly for
+running in EL2.
+
+Signed-off-by: Stephan Gerhold <stephan@gerhold.net>
+---
+ drivers/firmware/qcom/qcom_tzmem.c | 26 +++++++++++++++++++++-----
+ 1 file changed, 21 insertions(+), 5 deletions(-)
+
+diff --git a/drivers/firmware/qcom/qcom_tzmem.c b/drivers/firmware/qcom/qcom_tzmem.c
+index 0635cbeacfc8..d800c29c325b 100644
+--- a/drivers/firmware/qcom/qcom_tzmem.c
++++ b/drivers/firmware/qcom/qcom_tzmem.c
+@@ -71,9 +71,12 @@ static void qcom_tzmem_cleanup_area(struct qcom_tzmem_area *area)
+ #include <linux/firmware/qcom/qcom_scm.h>
+ #include <linux/of.h>
+ 
++#define QCOM_SHM_BRIDGE_SELF_OWNER BIT(1)
++#define QCOM_SHM_BRIDGE_SELF_OWNER_PERM_SHIFT 2
+ #define QCOM_SHM_BRIDGE_NUM_VM_SHIFT 9
+ 
+ static bool qcom_tzmem_using_shm_bridge;
++static u32 qcom_tzmem_vmid = QCOM_SCM_VMID_HLOS;
+ 
+ /* List of machines that are known to not support SHM bridge correctly. */
+ static const char *const qcom_tzmem_blacklist[] = {
+@@ -91,9 +94,15 @@ static int qcom_tzmem_init(void)
+ 	const char *const *platform;
+ 	int ret;
+ 
+-	for (platform = qcom_tzmem_blacklist; *platform; platform++) {
+-		if (of_machine_is_compatible(*platform))
+-			goto notsupp;
++	device_property_read_u32(qcom_tzmem_dev, "qcom,shm-bridge-vmid",
++				 &qcom_tzmem_vmid);
++
++	/* Skip blocklist if self owner is requested */
++	if (qcom_tzmem_vmid != QCOM_SCM_VMID_SELF_OWNER) {
++		for (platform = qcom_tzmem_blacklist; *platform; platform++) {
++			if (of_machine_is_compatible(*platform))
++				goto notsupp;
++		}
+ 	}
+ 
+ 	ret = qcom_scm_shm_bridge_enable(qcom_tzmem_dev);
+@@ -125,6 +134,7 @@ static int qcom_tzmem_init(void)
+ int qcom_tzmem_shm_bridge_create(phys_addr_t paddr, size_t size, u64 *handle)
+ {
+ 	u64 pfn_and_ns_perm, ipfn_and_s_perm, size_and_flags;
++	u64 ns_vmids = qcom_tzmem_vmid;
+ 	int ret;
+ 
+ 	if (!qcom_tzmem_using_shm_bridge)
+@@ -134,9 +144,15 @@ int qcom_tzmem_shm_bridge_create(phys_addr_t paddr, size_t size, u64 *handle)
+ 	ipfn_and_s_perm = paddr | QCOM_SCM_PERM_RW;
+ 	size_and_flags = size | (1 << QCOM_SHM_BRIDGE_NUM_VM_SHIFT);
+ 
++	if (qcom_tzmem_vmid == QCOM_SCM_VMID_SELF_OWNER) {
++		size_and_flags = size | QCOM_SHM_BRIDGE_SELF_OWNER |
++				 (QCOM_SCM_PERM_RW << QCOM_SHM_BRIDGE_SELF_OWNER_PERM_SHIFT);
++		ns_vmids = 0;
++	}
++
++
+ 	ret = qcom_scm_shm_bridge_create(pfn_and_ns_perm, ipfn_and_s_perm,
+-					 size_and_flags, QCOM_SCM_VMID_HLOS,
+-					 handle);
++					 size_and_flags, ns_vmids, handle);
+ 	if (ret) {
+ 		dev_err(qcom_tzmem_dev,
+ 			"SHM Bridge failed: ret %d paddr 0x%pa, size %zu\n",
+-- 
+2.43.0
+

--- a/patch sets/el2/0014-arm64-dts-qcom-sc7180-el2-Set-correct-owner-for-SCM-.patch
+++ b/patch sets/el2/0014-arm64-dts-qcom-sc7180-el2-Set-correct-owner-for-SCM-.patch
@@ -1,0 +1,35 @@
+From 9fe31c4e27010372682edf8ef6d7a4eea988ecd0 Mon Sep 17 00:00:00 2001
+From: Stephan Gerhold <stephan@gerhold.net>
+Date: Sun, 26 Oct 2025 14:52:44 +0100
+Subject: [PATCH 14/24] arm64: dts: qcom: sc7180-el2: Set correct owner for SCM
+ SHM bridge
+
+Signed-off-by: Stephan Gerhold <stephan@gerhold.net>
+---
+ arch/arm64/boot/dts/qcom/sc7180-el2.dtso | 5 +++++
+ 1 file changed, 5 insertions(+)
+
+diff --git a/arch/arm64/boot/dts/qcom/sc7180-el2.dtso b/arch/arm64/boot/dts/qcom/sc7180-el2.dtso
+index 6e8da59597b6..fe9c763b055c 100644
+--- a/arch/arm64/boot/dts/qcom/sc7180-el2.dtso
++++ b/arch/arm64/boot/dts/qcom/sc7180-el2.dtso
+@@ -1,4 +1,5 @@
+ // SPDX-License-Identifier: BSD-3-Clause
++#include <dt-bindings/firmware/qcom,scm.h>
+ 
+ /*
+  * sc7180 specific modifications required to boot in EL2.
+@@ -12,6 +13,10 @@ &gpu_zap_shader {
+ 	status = "disabled";
+ };
+ 
++&scm {
++	qcom,shm-bridge-vmid = <QCOM_SCM_VMID_SELF_OWNER>;
++};
++
+ /* Venus can be used in EL2 if booted similarly to ChromeOS devices. */
+ &venus {
+ 	video-firmware {
+-- 
+2.43.0
+

--- a/patch sets/el2/0015-arm64-dts-qcom-sc8280xp-el2-Set-correct-owner-for-SC.patch
+++ b/patch sets/el2/0015-arm64-dts-qcom-sc8280xp-el2-Set-correct-owner-for-SC.patch
@@ -1,0 +1,32 @@
+From d6d1166e8ba0aad3b40693754c886e9ff83220f2 Mon Sep 17 00:00:00 2001
+From: Stephan Gerhold <stephan@gerhold.net>
+Date: Sun, 26 Oct 2025 14:52:44 +0100
+Subject: [PATCH 15/24] arm64: dts: qcom: sc8280xp-el2: Set correct owner for
+ SCM SHM bridge
+
+Signed-off-by: Stephan Gerhold <stephan@gerhold.net>
+---
+ arch/arm64/boot/dts/qcom/sc8280xp-el2.dtso | 5 +++++
+ 1 file changed, 5 insertions(+)
+
+diff --git a/arch/arm64/boot/dts/qcom/sc8280xp-el2.dtso b/arch/arm64/boot/dts/qcom/sc8280xp-el2.dtso
+index cff3735a12dd..da2ab92542f8 100644
+--- a/arch/arm64/boot/dts/qcom/sc8280xp-el2.dtso
++++ b/arch/arm64/boot/dts/qcom/sc8280xp-el2.dtso
+@@ -1,4 +1,5 @@
+ // SPDX-License-Identifier: BSD-3-Clause
++#include <dt-bindings/firmware/qcom,scm.h>
+ 
+ /*
+  * sc8280xp specific modifications required to boot in EL2.
+@@ -40,3 +41,7 @@ &pcie4 {
+ &pcie_smmu {
+ 	status = "okay";
+ };
++
++&scm {
++	qcom,shm-bridge-vmid = <QCOM_SCM_VMID_SELF_OWNER>;
++};
+-- 
+2.43.0
+

--- a/patch sets/el2/0016-arm64-dts-qcom-x1-el2-Set-correct-owner-for-SCM-SHM-.patch
+++ b/patch sets/el2/0016-arm64-dts-qcom-x1-el2-Set-correct-owner-for-SCM-SHM-.patch
@@ -1,0 +1,32 @@
+From 34771929c76fbb44795d2375451edb57e2490a13 Mon Sep 17 00:00:00 2001
+From: Stephan Gerhold <stephan@gerhold.net>
+Date: Sun, 26 Oct 2025 14:52:44 +0100
+Subject: [PATCH 16/24] arm64: dts: qcom: x1-el2: Set correct owner for SCM SHM
+ bridge
+
+Signed-off-by: Stephan Gerhold <stephan@gerhold.net>
+---
+ arch/arm64/boot/dts/qcom/x1-el2.dtso | 5 +++++
+ 1 file changed, 5 insertions(+)
+
+diff --git a/arch/arm64/boot/dts/qcom/x1-el2.dtso b/arch/arm64/boot/dts/qcom/x1-el2.dtso
+index 175679be01eb..16b10ab7e815 100644
+--- a/arch/arm64/boot/dts/qcom/x1-el2.dtso
++++ b/arch/arm64/boot/dts/qcom/x1-el2.dtso
+@@ -1,4 +1,5 @@
+ // SPDX-License-Identifier: BSD-3-Clause
++#include <dt-bindings/firmware/qcom,scm.h>
+ 
+ /*
+  * x1 specific modifications required to boot in EL2.
+@@ -59,3 +60,7 @@ &pcie_smmu {
+ &sbsa_watchdog {
+ 	status = "disabled";
+ };
++
++&scm {
++	qcom,shm-bridge-vmid = <QCOM_SCM_VMID_SELF_OWNER>;
++};
+-- 
+2.43.0
+

--- a/patch sets/el2/0017-wip-remoteproc-qcom_q6v5_pas-Avoid-using-broken-rese.patch
+++ b/patch sets/el2/0017-wip-remoteproc-qcom_q6v5_pas-Avoid-using-broken-rese.patch
@@ -1,0 +1,120 @@
+From b636390249939606c00b2bdd08700cd1c72ef93b Mon Sep 17 00:00:00 2001
+From: Stephan Gerhold <stephan@gerhold.net>
+Date: Wed, 30 Jul 2025 16:35:46 +0200
+Subject: [PATCH 17/24] wip: remoteproc: qcom_q6v5_pas: Avoid using broken
+ reset when running bare-metal
+
+Some firmware versions have a split design where firmware authentication is
+implemented in the TZ firmware, but the remoteproc reset sequence appears
+to be triggered by the hypervisor firmware. When running bare-metal without
+the hypervisor only the firmware authentication functionality is present.
+Without knowledge of the exact hardware reset register sequence, we cannot
+(re)start the remoteproc from Linux.
+
+This does not make the qcom_q6v5_pas driver useless. In case the remoteproc
+is already running during boot, we can attach to it as usual and keep using
+it until it crashes or is manually stopped. Not being able to restart it is
+not ideal, but not a big loss: A remoteproc should rarely (if ever) crash
+during normal use. Also, currently most drivers upstream cannot properly
+handle a remoteproc crash anyway (without full system restart).
+
+Detecting this case automatically is tricky since all the PAS related calls
+still succeed, it will just not release the remoteproc from reset. Also, on
+SC7180, MPSS does always work correctly, only ADSP and CDSP are broken.
+Look for a new "qcom,broken-reset" property so we can check which of the
+remoteprocs are affected.
+
+Signed-off-by: Stephan Gerhold <stephan@gerhold.net>
+---
+ drivers/remoteproc/qcom_q6v5_pas.c | 32 +++++++++++++++++++++++++++---
+ 1 file changed, 29 insertions(+), 3 deletions(-)
+
+diff --git a/drivers/remoteproc/qcom_q6v5_pas.c b/drivers/remoteproc/qcom_q6v5_pas.c
+index a84745add654..38178e8a764f 100644
+--- a/drivers/remoteproc/qcom_q6v5_pas.c
++++ b/drivers/remoteproc/qcom_q6v5_pas.c
+@@ -567,6 +567,13 @@ static const struct rproc_ops qcom_pas_minidump_ops = {
+ 	.coredump = qcom_pas_minidump,
+ };
+ 
++static const struct rproc_ops qcom_pas_ops_no_reset = {
++	.attach = qcom_pas_attach,
++	.da_to_va = qcom_pas_da_to_va,
++	.stop = qcom_pas_stop,
++	.panic = qcom_pas_panic,
++};
++
+ static int qcom_pas_init_clock(struct qcom_pas *pas)
+ {
+ 	pas->xo = devm_clk_get(pas->dev, "xo");
+@@ -802,6 +809,9 @@ static int qcom_pas_probe(struct platform_device *pdev)
+ 	if (desc->minidump_id)
+ 		ops = &qcom_pas_minidump_ops;
+ 
++	if (device_property_read_bool(&pdev->dev, "qcom,broken-reset"))
++		ops = &qcom_pas_ops_no_reset;
++
+ 	rproc = devm_rproc_alloc(&pdev->dev, desc->sysmon_name, ops, fw_name, sizeof(*pas));
+ 
+ 	if (!rproc) {
+@@ -810,10 +820,14 @@ static int qcom_pas_probe(struct platform_device *pdev)
+ 	}
+ 
+ 	rproc->has_iommu = of_property_present(pdev->dev.of_node, "iommus");
+-	if (desc->auto_boot)
+-		rproc->auto_boot = RPROC_AUTO_BOOT_RESTART_IF_FW_AVAILABLE;
+-	else
++	if (desc->auto_boot) {
++		if (ops->start)
++			rproc->auto_boot = RPROC_AUTO_BOOT_RESTART_IF_FW_AVAILABLE;
++		else
++			rproc->auto_boot = RPROC_AUTO_BOOT_ATTACH_OR_START;
++	} else {
+ 		rproc->auto_boot = RPROC_AUTO_BOOT_DISABLED;
++	}
+ 	rproc_coredump_set_elf_info(rproc, ELFCLASS32, EM_NONE);
+ 
+ 	pas = rproc->priv;
+@@ -874,6 +888,13 @@ static int qcom_pas_probe(struct platform_device *pdev)
+ 	 */
+ 	qcom_q6v5_read_smp2p_state(&pas->q6v5);
+ 
++	if (rproc->state == RPROC_OFFLINE && !ops->start) {
++		dev_err(&pdev->dev, "reset broken and remoteproc not running during boot, exiting\n");
++		/* Release all resources, but return 0 so we don't block sync_state() */
++		ret = 0;
++		goto deinit_q6v5;
++	}
++
+ 	qcom_add_glink_subdev(rproc, &pas->glink_subdev, desc->ssr_name);
+ 	qcom_add_smd_subdev(rproc, &pas->smd_subdev);
+ 	qcom_add_pdm_subdev(rproc, &pas->pdm_subdev);
+@@ -915,6 +936,7 @@ static int qcom_pas_probe(struct platform_device *pdev)
+ 	qcom_remove_pdm_subdev(rproc, &pas->pdm_subdev);
+ 	qcom_remove_smd_subdev(rproc, &pas->smd_subdev);
+ 	qcom_remove_glink_subdev(rproc, &pas->glink_subdev);
++deinit_q6v5:
+ 	qcom_q6v5_deinit(&pas->q6v5);
+ detach_proxy_pds:
+ 	qcom_pas_pds_detach(pas, pas->proxy_pds, pas->proxy_pd_count);
+@@ -922,6 +944,7 @@ static int qcom_pas_probe(struct platform_device *pdev)
+ 	qcom_pas_unassign_memory_region(pas);
+ free_rproc:
+ 	device_init_wakeup(pas->dev, false);
++	pas->rproc = NULL;
+ 
+ 	return ret;
+ }
+@@ -930,6 +953,9 @@ static void qcom_pas_remove(struct platform_device *pdev)
+ {
+ 	struct qcom_pas *pas = platform_get_drvdata(pdev);
+ 
++	if (!pas->rproc)
++		return;
++
+ 	rproc_del(pas->rproc);
+ 
+ 	qcom_q6v5_deinit(&pas->q6v5);
+-- 
+2.43.0
+

--- a/patch sets/el2/0018-arm64-dts-qcom-sc7180-el2-Add-qcom-broken-reset-wher.patch
+++ b/patch sets/el2/0018-arm64-dts-qcom-sc7180-el2-Add-qcom-broken-reset-wher.patch
@@ -1,0 +1,42 @@
+From 9fea1eab7c56f846ac02badc4def48df07c628aa Mon Sep 17 00:00:00 2001
+From: Stephan Gerhold <stephan@gerhold.net>
+Date: Wed, 30 Jul 2025 16:17:46 +0200
+Subject: [PATCH 18/24] arm64: dts: qcom: sc7180-el2: Add qcom,broken-reset
+ where needed
+
+The remoteproc PAS firmware interface does not work properly when running
+bare-metal without hypervisor in EL2. It's possible to authenticate and
+start new firmware, but the remoteproc is never actually brought out of
+reset. On SC7180 this only affects the ADSP, MPSS works correctly.
+
+Mark the ADSP with "qcom,broken-reset" to make the driver skip trying to
+reset the remoteproc. We can still attach to it if it is already running
+during boot.
+
+Signed-off-by: Stephan Gerhold <stephan@gerhold.net>
+---
+ arch/arm64/boot/dts/qcom/sc7180-el2.dtso | 8 ++++++++
+ 1 file changed, 8 insertions(+)
+
+diff --git a/arch/arm64/boot/dts/qcom/sc7180-el2.dtso b/arch/arm64/boot/dts/qcom/sc7180-el2.dtso
+index fe9c763b055c..ecb6327cb522 100644
+--- a/arch/arm64/boot/dts/qcom/sc7180-el2.dtso
++++ b/arch/arm64/boot/dts/qcom/sc7180-el2.dtso
+@@ -13,6 +13,14 @@ &gpu_zap_shader {
+ 	status = "disabled";
+ };
+ 
++&remoteproc_adsp {
++	qcom,broken-reset;
++};
++
++&remoteproc_mpss {
++	/* Reset is implemented in TZ firmware, so no qcom,broken-reset here */
++};
++
+ &scm {
+ 	qcom,shm-bridge-vmid = <QCOM_SCM_VMID_SELF_OWNER>;
+ };
+-- 
+2.43.0
+

--- a/patch sets/el2/0019-arm64-dts-qcom-sc8280xp-el2-Add-qcom-broken-reset-fo.patch
+++ b/patch sets/el2/0019-arm64-dts-qcom-sc8280xp-el2-Add-qcom-broken-reset-fo.patch
@@ -1,0 +1,50 @@
+From 46900d9d669d16e5936e10ab84329be6086070b4 Mon Sep 17 00:00:00 2001
+From: Stephan Gerhold <stephan@gerhold.net>
+Date: Wed, 30 Jul 2025 16:17:46 +0200
+Subject: [PATCH 19/24] arm64: dts: qcom: sc8280xp-el2: Add qcom,broken-reset
+ for remoteprocs
+
+The remoteproc PAS firmware interface does not work properly when running
+bare-metal without hypervisor in EL2. It's possible to authenticate and
+start new firmware, but the remoteproc is never actually brought out of
+reset. On SC8280XP this affects all remoteprocs: ADSP, both CDSP and SLPI.
+
+Mark all these with "qcom,broken-reset" to make the driver skip trying to
+reset the remoteproc. We can still attach to them if they are already
+running during boot.
+
+Signed-off-by: Stephan Gerhold <stephan@gerhold.net>
+---
+ arch/arm64/boot/dts/qcom/sc8280xp-el2.dtso | 16 ++++++++++++++++
+ 1 file changed, 16 insertions(+)
+
+diff --git a/arch/arm64/boot/dts/qcom/sc8280xp-el2.dtso b/arch/arm64/boot/dts/qcom/sc8280xp-el2.dtso
+index da2ab92542f8..e43018f21105 100644
+--- a/arch/arm64/boot/dts/qcom/sc8280xp-el2.dtso
++++ b/arch/arm64/boot/dts/qcom/sc8280xp-el2.dtso
+@@ -42,6 +42,22 @@ &pcie_smmu {
+ 	status = "okay";
+ };
+ 
++&remoteproc_adsp {
++	qcom,broken-reset;
++};
++
++&remoteproc_slpi {
++	qcom,broken-reset;
++};
++
++&remoteproc_nsp0 {
++	qcom,broken-reset;
++};
++
++&remoteproc_nsp1 {
++	qcom,broken-reset;
++};
++
+ &scm {
+ 	qcom,shm-bridge-vmid = <QCOM_SCM_VMID_SELF_OWNER>;
+ };
+-- 
+2.43.0
+

--- a/patch sets/el2/0020-arm64-dts-qcom-x1-el2-Add-qcom-broken-reset-for-remo.patch
+++ b/patch sets/el2/0020-arm64-dts-qcom-x1-el2-Add-qcom-broken-reset-for-remo.patch
@@ -1,0 +1,44 @@
+From bc0f1fff33d0ef86564d98266cb7cc1ac20d9f02 Mon Sep 17 00:00:00 2001
+From: Stephan Gerhold <stephan@gerhold.net>
+Date: Wed, 30 Jul 2025 16:17:46 +0200
+Subject: [PATCH 20/24] arm64: dts: qcom: x1-el2: Add qcom,broken-reset for
+ remoteprocs
+
+The remoteproc PAS firmware interface does not work properly when running
+bare-metal without hypervisor in EL2. It's possible to authenticate and
+start new firmware, but the remoteproc is never actually brought out of
+reset. On X1E this affects all remoteprocs: ADSP and CDSP.
+
+Mark both with "qcom,broken-reset" to make the driver skip trying to reset
+the remoteproc. We can still attach to them if they are already running
+during boot. On X1E, the "lite" ADSP firmware should be always running
+already during boot, and it provides at least battery status/charging as
+well as USB-C detection for external displays.
+
+Signed-off-by: Stephan Gerhold <stephan@gerhold.net>
+---
+ arch/arm64/boot/dts/qcom/x1-el2.dtso | 8 ++++++++
+ 1 file changed, 8 insertions(+)
+
+diff --git a/arch/arm64/boot/dts/qcom/x1-el2.dtso b/arch/arm64/boot/dts/qcom/x1-el2.dtso
+index 16b10ab7e815..e44ea5632639 100644
+--- a/arch/arm64/boot/dts/qcom/x1-el2.dtso
++++ b/arch/arm64/boot/dts/qcom/x1-el2.dtso
+@@ -53,6 +53,14 @@ &pcie_smmu {
+ 	status = "okay";
+ };
+ 
++&remoteproc_adsp {
++	qcom,broken-reset;
++};
++
++&remoteproc_cdsp {
++	qcom,broken-reset;
++};
++
+ /*
+  * The "SBSA watchdog" is implemented in software in Gunyah
+  * and can't be used when running in EL2.
+-- 
+2.43.0
+

--- a/patch sets/el2/0021-hack-soc-qcom-pmic_glink-Avoid-platform-rpmsg-probe-.patch
+++ b/patch sets/el2/0021-hack-soc-qcom-pmic_glink-Avoid-platform-rpmsg-probe-.patch
@@ -1,0 +1,92 @@
+From 39aa47f538b739e966e4c6eab629ab3f2eacbd2b Mon Sep 17 00:00:00 2001
+From: Stephan Gerhold <stephan.gerhold@linaro.org>
+Date: Wed, 8 Oct 2025 12:28:36 +0200
+Subject: [PATCH 21/24] hack: soc: qcom: pmic_glink: Avoid platform/rpmsg probe
+ race condition
+
+If the rpmsg device probes before the platform device, PMIC GLINK setup
+will fail with
+
+6800000.remoteproc:glink-edge.PMIC_RTR_ADSP_APPS.-1.-1: error -ENODEV: no
+pmic_glink device to attach to
+
+As a workaround, register the rpmsg driver only after the PMIC GLINK
+platform device was probed. Returning -EPROBE_DEFER from the rpmsg driver
+does not seem to work because the rpmsg core doesn't handle EPROBE_DEFER(?)
+
+6800000.remoteproc:glink-edge.PMIC_RTR_ADSP_APPS.-1.-1: rpmsg_dev_probe:
+failed: -517
+
+This needs more investigation.
+---
+ drivers/soc/qcom/pmic_glink.c | 38 ++++++++++++-----------------------
+ 1 file changed, 13 insertions(+), 25 deletions(-)
+
+diff --git a/drivers/soc/qcom/pmic_glink.c b/drivers/soc/qcom/pmic_glink.c
+index 627f96ca322e..c073d7e2ede6 100644
+--- a/drivers/soc/qcom/pmic_glink.c
++++ b/drivers/soc/qcom/pmic_glink.c
+@@ -349,8 +349,18 @@ static int pmic_glink_probe(struct platform_device *pdev)
+ 	__pmic_glink = pg;
+ 	mutex_unlock(&__pmic_glink_lock);
+ 
++	ret = register_rpmsg_driver(&pmic_glink_rpmsg_driver);
++	if (ret) {
++		ret = dev_err_probe(&pdev->dev, ret, "failed to register rpmsg driver\n");
++		goto out_release_pmic_glink;
++	}
++
+ 	return 0;
+ 
++out_release_pmic_glink:
++	mutex_lock(&__pmic_glink_lock);
++	__pmic_glink = NULL;
++	mutex_unlock(&__pmic_glink_lock);
+ out_release_aux_devices:
+ 	if (pg->client_mask & BIT(PMIC_GLINK_CLIENT_BATT))
+ 		pmic_glink_del_aux_device(pg, &pg->ps_aux);
+@@ -379,6 +389,8 @@ static void pmic_glink_remove(struct platform_device *pdev)
+ 	if (pg->client_mask & BIT(PMIC_GLINK_CLIENT_UCSI))
+ 		pmic_glink_del_aux_device(pg, &pg->ucsi_aux);
+ 
++	unregister_rpmsg_driver(&pmic_glink_rpmsg_driver);
++
+ 	guard(mutex)(&__pmic_glink_lock);
+ 	__pmic_glink = NULL;
+ }
+@@ -401,31 +413,7 @@ static struct platform_driver pmic_glink_driver = {
+ 		.of_match_table = pmic_glink_of_match,
+ 	},
+ };
+-
+-static int pmic_glink_init(void)
+-{
+-	int ret;
+-
+-	ret = platform_driver_register(&pmic_glink_driver);
+-	if (ret < 0)
+-		return ret;
+-
+-	ret = register_rpmsg_driver(&pmic_glink_rpmsg_driver);
+-	if (ret < 0) {
+-		platform_driver_unregister(&pmic_glink_driver);
+-		return ret;
+-	}
+-
+-	return 0;
+-}
+-module_init(pmic_glink_init);
+-
+-static void pmic_glink_exit(void)
+-{
+-	unregister_rpmsg_driver(&pmic_glink_rpmsg_driver);
+-	platform_driver_unregister(&pmic_glink_driver);
+-}
+-module_exit(pmic_glink_exit);
++module_platform_driver(pmic_glink_driver);
+ 
+ MODULE_DESCRIPTION("Qualcomm PMIC GLINK driver");
+ MODULE_LICENSE("GPL");
+-- 
+2.43.0
+

--- a/patch sets/el2/0022-rpmsg-core-Call-announce_destroy-only-after-announce.patch
+++ b/patch sets/el2/0022-rpmsg-core-Call-announce_destroy-only-after-announce.patch
@@ -1,0 +1,34 @@
+From d3e7469f02e940d2524ccb6d21920415c7fbe596 Mon Sep 17 00:00:00 2001
+From: Stephan Gerhold <stephan.gerhold@linaro.org>
+Date: Sat, 1 Nov 2025 18:32:25 +0100
+Subject: [PATCH 22/24] rpmsg: core: Call announce_destroy() only after
+ announce_create()
+
+rpmsg_dev_probe() calls rpdev->ops->announce_create() only when the driver
+specifies a callback and an endpoint was opened, but rpmsg_dev_remove()
+calls announce_destroy() unconditionally. Fix this by adding the missing
+check.
+
+Cc: stable@vger.kernel.org
+Fixes: 7586516ca043 ("rpmsg: Only invoke announce_create for rpdev with endpoints")
+Signed-off-by: Stephan Gerhold <stephan.gerhold@linaro.org>
+---
+ drivers/rpmsg/rpmsg_core.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/drivers/rpmsg/rpmsg_core.c b/drivers/rpmsg/rpmsg_core.c
+index 96964745065b..e23a024856ee 100644
+--- a/drivers/rpmsg/rpmsg_core.c
++++ b/drivers/rpmsg/rpmsg_core.c
+@@ -521,7 +521,7 @@ static void rpmsg_dev_remove(struct device *dev)
+ 	struct rpmsg_device *rpdev = to_rpmsg_device(dev);
+ 	struct rpmsg_driver *rpdrv = to_rpmsg_driver(rpdev->dev.driver);
+ 
+-	if (rpdev->ops->announce_destroy)
++	if (rpdev->ept && rpdev->ops->announce_destroy)
+ 		rpdev->ops->announce_destroy(rpdev);
+ 
+ 	if (rpdrv->remove)
+-- 
+2.43.0
+

--- a/patch sets/el2/0023-rpmsg-core-Make-it-easier-to-manually-create-endpoin.patch
+++ b/patch sets/el2/0023-rpmsg-core-Make-it-easier-to-manually-create-endpoin.patch
@@ -1,0 +1,174 @@
+From 0c0ab479435dafd626a1ccdada199841ff325717 Mon Sep 17 00:00:00 2001
+From: Stephan Gerhold <stephan.gerhold@linaro.org>
+Date: Sat, 1 Nov 2025 18:33:26 +0100
+Subject: [PATCH 23/24] rpmsg: core: Make it easier to manually create endpoint
+ during probe()
+
+Currently, the rpmsg core automatically creates an endpoint for rpmsg
+drivers that specify a receive callback. This works "somewhat" in most
+simple cases, but it is often prone to race conditions: The receive
+callback can be called as soon and as long as the endpoint is open, so
+drivers must be prepared to handle calls to the receive callback:
+
+ - Before their probe() function is called
+   (after the endpoint was created)
+ - In parallel to their probe() function
+ - In parallel to their remove() function
+ - After their remove() function is called
+   (before the endpoint is destroyed)
+
+It is difficult for drivers to handle this without being able to run code
+before endpoint creation and after endpoint destruction. Also, they may
+need to hold locks while creating/destroying the endpoint to handle edge
+cases reliably.
+
+Drivers can already create endpoints manually by omitting the receive
+callback in rpmsg_driver, but for most simple cases where there is only
+a single channel, the boilerplate required for that is a bit cumbersome.
+
+Add a rpmsg_dev_open_ept() function that can be called by drivers during
+the probe() function. It results in effectively the same that the rpmsg
+core would normally do if the receive callback is specified.
+announce_create() and announce_destroy() are still handled by the rpmsg
+core. During remove(), the drivers can directly call rpmsg_destroy_ept().
+
+Signed-off-by: Stephan Gerhold <stephan.gerhold@linaro.org>
+---
+ drivers/rpmsg/rpmsg_core.c | 51 +++++++++++++++++++++++++++-----------
+ include/linux/rpmsg.h      | 12 +++++++++
+ 2 files changed, 49 insertions(+), 14 deletions(-)
+
+diff --git a/drivers/rpmsg/rpmsg_core.c b/drivers/rpmsg/rpmsg_core.c
+index e23a024856ee..51723e55bde1 100644
+--- a/drivers/rpmsg/rpmsg_core.c
++++ b/drivers/rpmsg/rpmsg_core.c
+@@ -95,6 +95,14 @@ EXPORT_SYMBOL(rpmsg_release_channel);
+  * equals to the src address of their rpmsg channel), the driver's handler
+  * is invoked to process it.
+  *
++ * Note that the endpoint for simple rpmsg drivers is created before calling
++ * probe() and closed after calling remove(), so special care must be taken
++ * to handle calls to the rx callback before/in parallel of probe() and
++ * after/in parallel of remove(). If more control over the endpoint creation
++ * is required to avoid race conditions, drivers can omit the callback and
++ * explicitly call rpmsg_dev_open_ept() in probe() and rpmsg_destroy_ept() in
++ * remove(), together with locks as needed.
++ *
+  * That said, more complicated drivers might need to allocate
+  * additional rpmsg addresses, and bind them to different rx callbacks.
+  * To accomplish that, those drivers need to call this function.
+@@ -451,6 +459,32 @@ static int rpmsg_uevent(const struct device *dev, struct kobj_uevent_env *env)
+ 					rpdev->id.name);
+ }
+ 
++struct rpmsg_endpoint *rpmsg_dev_open_ept(struct rpmsg_device *rpdev,
++					  rpmsg_rx_cb_t cb, void *priv)
++{
++	struct rpmsg_driver *rpdrv = to_rpmsg_driver(rpdev->dev.driver);
++	struct rpmsg_channel_info chinfo = {
++		.src = rpdev->src,
++		.dst = RPMSG_ADDR_ANY,
++	};
++	struct rpmsg_endpoint *ept;
++
++	strscpy(chinfo.name, rpdev->id.name, sizeof(chinfo.name));
++
++	ept = rpmsg_create_ept(rpdev, cb, priv, chinfo);
++	if (!ept) {
++		dev_err(&rpdev->dev, "failed to create endpoint\n");
++		return NULL;
++	}
++
++	rpdev->ept = ept;
++	rpdev->src = ept->addr;
++
++	ept->flow_cb = rpdrv->flowcontrol;
++	return ept;
++}
++EXPORT_SYMBOL(rpmsg_dev_open_ept);
++
+ /*
+  * when an rpmsg driver is probed with a channel, we seamlessly create
+  * it an endpoint, binding its rx callback to a unique local rpmsg
+@@ -463,7 +497,6 @@ static int rpmsg_dev_probe(struct device *dev)
+ {
+ 	struct rpmsg_device *rpdev = to_rpmsg_device(dev);
+ 	struct rpmsg_driver *rpdrv = to_rpmsg_driver(rpdev->dev.driver);
+-	struct rpmsg_channel_info chinfo = {};
+ 	struct rpmsg_endpoint *ept = NULL;
+ 	int err;
+ 
+@@ -473,21 +506,11 @@ static int rpmsg_dev_probe(struct device *dev)
+ 		goto out;
+ 
+ 	if (rpdrv->callback) {
+-		strscpy(chinfo.name, rpdev->id.name, sizeof(chinfo.name));
+-		chinfo.src = rpdev->src;
+-		chinfo.dst = RPMSG_ADDR_ANY;
+-
+-		ept = rpmsg_create_ept(rpdev, rpdrv->callback, NULL, chinfo);
++		ept = rpmsg_dev_open_ept(rpdev, rpdrv->callback, NULL);
+ 		if (!ept) {
+-			dev_err(dev, "failed to create endpoint\n");
+ 			err = -ENOMEM;
+ 			goto out;
+ 		}
+-
+-		rpdev->ept = ept;
+-		rpdev->src = ept->addr;
+-
+-		ept->flow_cb = rpdrv->flowcontrol;
+ 	}
+ 
+ 	err = rpdrv->probe(rpdev);
+@@ -496,7 +519,7 @@ static int rpmsg_dev_probe(struct device *dev)
+ 		goto destroy_ept;
+ 	}
+ 
+-	if (ept && rpdev->ops->announce_create) {
++	if (rpdev->ept && rpdev->ops->announce_create) {
+ 		err = rpdev->ops->announce_create(rpdev);
+ 		if (err) {
+ 			dev_err(dev, "failed to announce creation\n");
+@@ -527,7 +550,7 @@ static void rpmsg_dev_remove(struct device *dev)
+ 	if (rpdrv->remove)
+ 		rpdrv->remove(rpdev);
+ 
+-	if (rpdev->ept)
++	if (rpdrv->callback && rpdev->ept)
+ 		rpmsg_destroy_ept(rpdev->ept);
+ }
+ 
+diff --git a/include/linux/rpmsg.h b/include/linux/rpmsg.h
+index fb7ab9165645..8cf3fa83fa95 100644
+--- a/include/linux/rpmsg.h
++++ b/include/linux/rpmsg.h
+@@ -181,6 +181,8 @@ void rpmsg_destroy_ept(struct rpmsg_endpoint *);
+ struct rpmsg_endpoint *rpmsg_create_ept(struct rpmsg_device *,
+ 					rpmsg_rx_cb_t cb, void *priv,
+ 					struct rpmsg_channel_info chinfo);
++struct rpmsg_endpoint *rpmsg_dev_open_ept(struct rpmsg_device *rpdev,
++					  rpmsg_rx_cb_t cb, void *priv);
+ 
+ int rpmsg_send(struct rpmsg_endpoint *ept, void *data, int len);
+ int rpmsg_sendto(struct rpmsg_endpoint *ept, void *data, int len, u32 dst);
+@@ -249,6 +251,16 @@ static inline struct rpmsg_endpoint *rpmsg_create_ept(struct rpmsg_device *rpdev
+ 	return NULL;
+ }
+ 
++static inline struct rpmsg_endpoint *rpmsg_dev_open_ept(struct rpmsg_device *rpdev,
++							rpmsg_rx_cb_t cb,
++							void *priv)
++{
++	/* This shouldn't be possible */
++	WARN_ON(1);
++
++	return NULL;
++}
++
+ static inline int rpmsg_send(struct rpmsg_endpoint *ept, void *data, int len)
+ {
+ 	/* This shouldn't be possible */
+-- 
+2.43.0
+

--- a/patch sets/el2/0024-net-qrtr-smd-Fix-race-conditions-while-opening-closi.patch
+++ b/patch sets/el2/0024-net-qrtr-smd-Fix-race-conditions-while-opening-closi.patch
@@ -1,0 +1,180 @@
+From 48fb65528275bee6850323ec07cd1057a4e61947 Mon Sep 17 00:00:00 2001
+From: Stephan Gerhold <stephan.gerhold@linaro.org>
+Date: Sat, 1 Nov 2025 18:33:53 +0100
+Subject: [PATCH 24/24] net: qrtr: smd: Fix race conditions while
+ opening/closing channel
+
+If rpmsg drivers specify a receive callback in the rpmsg_driver struct, the
+rpmsg core creates the endpoint (opens the channel) before calling the
+driver probe() function, and similarly it destroys the endpoint (closes the
+channel) after calling the driver remove() function. The receive callback
+can be invoked from interrupt context any time when the channel is open,
+before (or in parallel) of the probe() function, and after (or in parallel)
+of the remove() function. Only few rpmsg drivers handle that reliably.
+
+The QRTR SMD driver partially attempts to handle one of these edge cases by
+checking if dev_get_drvdata() is already set when the receive callback is
+invoked. If not, it returns -EAGAIN in the hope that the receive callback
+will be repeated at a later point in time. Unfortunately, this can still
+lead to problems:
+
+ - The qcom_smd rpmsg backend (somewhat) handles -EAGAIN because it
+   re-checks the channel status later during announce_create(), but the
+   glink smem backend simply ignores that. The rpmsg backend cannot really
+   know when "again" is supposed to be - during the next incoming
+   interrupt, in a few seconds, or in a few years?
+
+ - There are no memory barriers, so just because the driver data (set at
+   the end of the probe() function) already became visible does not mean
+   the whole struct has already become visible to another CPU.
+
+ - During remove(), the driver data is reset to NULL after the endpoint is
+   already unregistered. Packets could still come inbetween that.
+
+One rare issue that has been reported occasionally over the years is that
+the ADSP on Qualcomm compute platforms (e.g. X13s or X1E laptops) does not
+always come up reliably (depending on kernel configuration and timing). One
+particular symptom is that the ADSP appears to function correctly (e.g.
+charging LED changes state), but no QMI services are exposed via QRTR. This
+can happen when the initial QRTR "hello" packet gets dropped, which is sent
+by the remoteproc immediately upon opening the channel.
+
+In order to fix this issue properly, it is easiest to inverse the startup
+sequence and register the QRTR endpoint before opening the rpmsg channel.
+This is because we can easily block on a mutex lock in the send path, but
+could only use a short-running spin lock in the receive callback:
+
+ - Register the QRTR endpoint before opening the channel (and unregister
+   after closing the channel), so that we can always handle incoming
+   packets.
+
+ - Block the send path with a lock until we have fully initialized.
+
+ - During remove(), start rejecting all further send operations with
+   -ENODEV before we close the rpmsg channel.
+
+ - The startup ordering and the lock implicitly provide the necessary
+   memory barriers.
+
+Use the new rpmsg_dev_open_ept() function to have more control over the
+initialization order and add the necessary locking.
+
+It is difficult to identify a proper Fixes tag. The qcom_smd rpmsg backend
+that this driver was originally intended for (hence the name qrtr/smd.c)
+handles -EAGAIN somewhat, but the newer glink smem backend does not, so
+this is where things started (rarely) breaking.
+
+Cc: stable@vger.kernel.org
+Fixes: caf989c350e8 ("rpmsg: glink: Introduce glink smem based transport")
+Signed-off-by: Stephan Gerhold <stephan.gerhold@linaro.org>
+---
+ net/qrtr/smd.c | 41 ++++++++++++++++++++++++++++++++---------
+ 1 file changed, 32 insertions(+), 9 deletions(-)
+
+diff --git a/net/qrtr/smd.c b/net/qrtr/smd.c
+index c91bf030fbc7..bd70dcfe499a 100644
+--- a/net/qrtr/smd.c
++++ b/net/qrtr/smd.c
+@@ -5,6 +5,7 @@
+  */
+ 
+ #include <linux/module.h>
++#include <linux/mutex.h>
+ #include <linux/skbuff.h>
+ #include <linux/rpmsg.h>
+ 
+@@ -14,18 +15,18 @@ struct qrtr_smd_dev {
+ 	struct qrtr_endpoint ep;
+ 	struct rpmsg_endpoint *channel;
+ 	struct device *dev;
++
++	/* Protect against channel open/close while sending */
++	struct mutex send_lock;
+ };
+ 
+ /* from smd to qrtr */
+ static int qcom_smd_qrtr_callback(struct rpmsg_device *rpdev,
+ 				  void *data, int len, void *priv, u32 addr)
+ {
+-	struct qrtr_smd_dev *qdev = dev_get_drvdata(&rpdev->dev);
++	struct qrtr_smd_dev *qdev = priv;
+ 	int rc;
+ 
+-	if (!qdev)
+-		return -EAGAIN;
+-
+ 	rc = qrtr_endpoint_post(&qdev->ep, data, len);
+ 	if (rc == -EINVAL) {
+ 		dev_err(qdev->dev, "invalid ipcrouter packet\n");
+@@ -46,7 +47,12 @@ static int qcom_smd_qrtr_send(struct qrtr_endpoint *ep, struct sk_buff *skb)
+ 	if (rc)
+ 		goto out;
+ 
+-	rc = rpmsg_send(qdev->channel, skb->data, skb->len);
++	scoped_guard(mutex, &qdev->send_lock) {
++		if (qdev->channel)
++			rc = rpmsg_send(qdev->channel, skb->data, skb->len);
++		else
++			rc = -ENODEV;
++	}
+ 
+ out:
+ 	if (rc)
+@@ -65,14 +71,26 @@ static int qcom_smd_qrtr_probe(struct rpmsg_device *rpdev)
+ 	if (!qdev)
+ 		return -ENOMEM;
+ 
+-	qdev->channel = rpdev->ept;
+ 	qdev->dev = &rpdev->dev;
+ 	qdev->ep.xmit = qcom_smd_qrtr_send;
+ 
++	rc = devm_mutex_init(&rpdev->dev, &qdev->send_lock);
++	if (rc)
++		return rc;
++
++	/* Block sending until we have fully opened the channel */
++	guard(mutex)(&qdev->send_lock);
++
+ 	rc = qrtr_endpoint_register(&qdev->ep, QRTR_EP_NID_AUTO);
+ 	if (rc)
+ 		return rc;
+ 
++	qdev->channel = rpmsg_dev_open_ept(rpdev, qcom_smd_qrtr_callback, qdev);
++	if (!qdev->channel) {
++		qrtr_endpoint_unregister(&qdev->ep);
++		return -EREMOTEIO;
++	}
++
+ 	dev_set_drvdata(&rpdev->dev, qdev);
+ 
+ 	dev_dbg(&rpdev->dev, "Qualcomm SMD QRTR driver probed\n");
+@@ -83,10 +101,16 @@ static int qcom_smd_qrtr_probe(struct rpmsg_device *rpdev)
+ static void qcom_smd_qrtr_remove(struct rpmsg_device *rpdev)
+ {
+ 	struct qrtr_smd_dev *qdev = dev_get_drvdata(&rpdev->dev);
++	struct rpmsg_endpoint *ept;
+ 
+-	qrtr_endpoint_unregister(&qdev->ep);
++	/* We are about to close the channel, so stop all sending now */
++	scoped_guard(mutex, &qdev->send_lock) {
++		ept = qdev->channel;
++		qdev->channel = NULL;
++	}
+ 
+-	dev_set_drvdata(&rpdev->dev, NULL);
++	rpmsg_destroy_ept(ept);
++	qrtr_endpoint_unregister(&qdev->ep);
+ }
+ 
+ static const struct rpmsg_device_id qcom_smd_qrtr_smd_match[] = {
+@@ -97,7 +121,6 @@ static const struct rpmsg_device_id qcom_smd_qrtr_smd_match[] = {
+ static struct rpmsg_driver qcom_smd_qrtr_driver = {
+ 	.probe = qcom_smd_qrtr_probe,
+ 	.remove = qcom_smd_qrtr_remove,
+-	.callback = qcom_smd_qrtr_callback,
+ 	.id_table = qcom_smd_qrtr_smd_match,
+ 	.drv = {
+ 		.name = "qcom_smd_qrtr",
+-- 
+2.43.0
+


### PR DESCRIPTION
I have tested EL2 boot and KVM on this device, and both work properly.

With [`slbounce`](https://github.com/TravMurav/slbounce), [`qebspil`](https://github.com/stephan-gh/qebspil), and the required kernel-side patches, DSP / remoteproc-dependent functions such as audio can also work correctly in this setup.

These patches were cherry-picked/adapted from:
https://github.com/TravMurav/linux/tree/x13s-6.18-v1.1-cxsd