### PR TITLE
Several updates, Readme.md and a patch of DSI fix

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -70,7 +70,7 @@ Refer to [this](https://github.com/jhovold/linux/wiki/X13s) as well. If you want
 | USB | works | |
 | USB-PD | works | fast charging(45W+) supported with UCSI EC driver |
 | USB-C DisplayPort Alt Mode | works | it may be broken nowadays (untested since ~6.14) |
-| Video acceleration | works | see [below](#Video-acceleration) |
+| Video acceleration | partial | see [below](#Video-acceleration) |
 | Virtualisation | works | see [below](#Virtualisation)|
 | Volumn keys | works | |
 | Watchdog | partial | One in sc8280xp works, another in EC not |
@@ -273,8 +273,21 @@ but `libssc` does not expose this meter to `iio-sensor-proxy` somehow.
 ```
 
 ## Video acceleration
-Hardware video acceleration is supported via the Qualcomm Venus engine using the `v4l2m2m` API. Examples of usage:
-- **mpv**: `mpv --hwdec=v4l2m2m-copy <video>`
+Hardware decoding is supported via the Qualcomm Venus engine using the `v4l2m2m` API.
+
+For `mpv`, a simple user config for low-resource devices is:
+```ini
+profile=fast
+hwdec=v4l2m2m-copy
+vo=gpu
+swapchain-depth=8
+sws-fast=yes
+```
+
+Put it in `~/.config/mpv/mpv.conf`, or use it temporarily from the command line:
+- **mpv**: `mpv --hwdec=v4l2m2m-copy --vo=gpu --swapchain-depth=8 --sws-fast=yes <video>`
+
+Hardware encoding is not working yet.
 
 ## Virtualisation
 
@@ -282,8 +295,8 @@ EL2 / KVM works on gaokun with an EL2 boot flow.
 
 Minimal setup:
 - use [`slbounce`](https://github.com/TravMurav/slbounce) to switch into EL2 at `ExitBootServices()`
-- use [`qebspil`](https://github.com/stephan-gh/qebspil) before Linux boot if you want DSP / remoteproc-dependent functions (such as audio) to work in EL2
-- place the required firmware files in the correct EFI path
+- use [`qebspil`](https://github.com/stephan-gh/qebspil) before Linux boot, and apply the patches in [`patch sets/el2`](./patch%20sets/el2), if you want DSP / remoteproc-dependent functions (such as audio) to work in EL2
+- place the required firmware files and an old enough working `tcblaunch.exe` in the correct EFI path
 - boot Linux with the EL2 device tree (for example `sc8280xp-huawei-gaokun3-el2.dtb`)
 
 Kernel side should have virtualization, remoteproc, and Qualcomm PAS/Q6V5 support enabled.

--- a/patch sets/recommended/0014-drm-msm-dsi-avoid-link-clock-toggles-during-active-v.patch
+++ b/patch sets/recommended/0014-drm-msm-dsi-avoid-link-clock-toggles-during-active-v.patch
@@ -1,0 +1,55 @@
+From cb16e82fd8ff01b0b0f28a1690c61fafbae3037f Mon Sep 17 00:00:00 2001
+From: local builder <builder@example.com>
+Date: Sun, 5 Apr 2026 08:37:38 +0000
+Subject: [PATCH] drm/msm/dsi: avoid link clock toggles during active video cmd
+ xfer
+
+When command transfers are issued while video mode is already streaming, link clocks and OPP are already managed by the video enable path.
+Skip the extra link_clk_set_rate()/link_clk_enable() in xfer_prepare and the matching link_clk_disable()/pm_runtime_put() in xfer_restore for the active-video case.
+
+This avoids transient OPP drops during brightness DCS updates, which can cause visible panel corruption/flicker on bonded DSI setups.
+---
+ drivers/gpu/drm/msm/dsi/dsi_host.c | 20 ++++++++++++++------
+ 1 file changed, 14 insertions(+), 6 deletions(-)
+
+diff --git a/drivers/gpu/drm/msm/dsi/dsi_host.c b/drivers/gpu/drm/msm/dsi/dsi_host.c
+index db6da9937..c1c8a91e1 100644
+--- a/drivers/gpu/drm/msm/dsi/dsi_host.c
++++ b/drivers/gpu/drm/msm/dsi/dsi_host.c
+@@ -2132,9 +2132,16 @@ int msm_dsi_host_xfer_prepare(struct mipi_dsi_host *host,
+ 	 * mdss interrupt is generated in mdp core clock domain
+ 	 * mdp clock need to be enabled to receive dsi interrupt
+ 	 */
+-	pm_runtime_get_sync(&msm_host->pdev->dev);
+-	cfg_hnd->ops->link_clk_set_rate(msm_host);
+-	cfg_hnd->ops->link_clk_enable(msm_host);
++	/*
++	 * When video mode is streaming, clocks are already enabled and
++	 * OPP is set by the video enable path. Skip redundant clock ops
++	 * to avoid xfer_restore dropping OPP to 0 during active video.
++	 */
++	if (!(msm_host->power_on && msm_host->enabled)) {
++		pm_runtime_get_sync(&msm_host->pdev->dev);
++		cfg_hnd->ops->link_clk_set_rate(msm_host);
++		cfg_hnd->ops->link_clk_enable(msm_host);
++	}
+ 
+ 	/* TODO: vote for bus bandwidth */
+ 
+@@ -2164,9 +2171,10 @@ void msm_dsi_host_xfer_restore(struct mipi_dsi_host *host,
+ 		dsi_set_tx_power_mode(1, msm_host);
+ 
+ 	/* TODO: unvote for bus bandwidth */
+-
+-	cfg_hnd->ops->link_clk_disable(msm_host);
+-	pm_runtime_put(&msm_host->pdev->dev);
++	if (!(msm_host->power_on && msm_host->enabled)) {
++		cfg_hnd->ops->link_clk_disable(msm_host);
++		pm_runtime_put(&msm_host->pdev->dev);
++	}
+ }
+ 
+ int msm_dsi_host_cmd_tx(struct mipi_dsi_host *host,
+-- 
+2.53.0
+


### PR DESCRIPTION
- Clarify the Video acceleration section with recommended hardware decoding settings and note that encoding is not working yet.
- Document the extra EL2 requirements for Virtualisation, including a working old `tcblaunch.exe` and the `patch sets/el2` patches.
- Add a DSI fix to avoid redundant link clock toggles during active video command transfers, which fixes panel corruption or flicker when changing brightness.